### PR TITLE
new package: com.google.android.webview

### DIFF
--- a/modules/WebViewGoogle/Android.mk
+++ b/modules/WebViewGoogle/Android.mk
@@ -1,0 +1,8 @@
+# Auto-generated Makefile from OpenGapps. Do not modify.
+LOCAL_PATH := .
+include $(CLEAR_VARS)
+LOCAL_MODULE := WebViewGoogle
+LOCAL_PACKAGE_NAME := com.google.android.webview
+LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/priv-app
+
+include $(BUILD_GAPPS_PREBUILT_APK)


### PR DESCRIPTION
Switching from TK GApps to OpenGApps I noticed the Google Webview
package is not supported by aosp_build although the package itself is
provided by OpenGApps. Please note that I did not add this package to
any build variant, I leave the decision to you to decide whether this
package should be part of the pico build or any other variant.