### PR TITLE
build: Require GAPPS_VARIANT to be set

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ and add the following towards the end:
 
 **2. Set the desired OpenGapps variant**
 
-In your `device/manufacturer/product/BoardConfig.mk` file, towards the end, add:
+In your `device/manufacturer/product/device.mk` file, in the beginning, add:
 ```makefile
 GAPPS_VARIANT := <variant>
 ```
@@ -31,8 +31,6 @@ where `<variant>` is one of the [package types](https://github.com/opengapps/ope
 ```
 GAPPS_VARIANT := stock
 ```
-
-Defaults to `stock` if the value is not set.
 
 **3. Include the opengapps-packages.mk file**
 

--- a/config.mk
+++ b/config.mk
@@ -7,11 +7,13 @@ GAPPS_FILES := $(GAPPS_DEVICE_FILES_PATH)/opengapps-files.mk
 include $(GAPPS_BUILD_SYSTEM_PATH)/definitions.mk
 
 # Device should define their GAPPS_VARIANT in device/manufacturer/product/BoardConfig.mk
-GAPPS_VARIANT ?= stock
+ifeq ($(GAPPS_VARIANT),)
+	$(error GAPPS_VARIANT must be configured)
+endif
 GAPPS_VARIANT_EVAL := $(call get-gapps-variant,$(GAPPS_VARIANT))
 
 ifeq ($(GAPPS_VARIANT_EVAL),)
 $(error GAPPS_VARIANT $(GAPPS_VARIANT) was not found. Use of one of pico,nano,micro,mini,full,stock,super)
 endif
 
-GAPPS_VARIANT := $(GAPPS_VARIANT_EVAL)
+TARGET_GAPPS_VARIANT := $(GAPPS_VARIANT_EVAL)

--- a/modules/Chrome/Android.mk
+++ b/modules/Chrome/Android.mk
@@ -5,7 +5,7 @@ LOCAL_MODULE := Chrome
 LOCAL_PACKAGE_NAME := com.android.chrome
 LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/app
 
-ifneq ($(filter $(GAPPS_VARIANT),stock),) # overwrite Browser if stock/super
+ifneq ($(filter $(TARGET_GAPPS_VARIANT),stock),) # overwrite Browser if stock/super
 LOCAL_OVERRIDES_PACKAGES := Browser
 endif
 

--- a/opengapps-files.mk
+++ b/opengapps-files.mk
@@ -11,7 +11,7 @@ PRODUCT_COPY_FILES += $(GAPPS_SOURCES_ALL_PATH)/etc/permissions/com.google.widev
                       $(GAPPS_SOURCES_ALL_PATH)/framework/com.google.android.media.effects.jar:system/framework/com.google.android.media.effects.jar
 
 # Pico and higher
-ifneq ($(filter $(GAPPS_VARIANT),pico),)
+ifneq ($(filter $(TARGET_GAPPS_VARIANT),pico),)
 PRODUCT_COPY_FILES += \
                       $(GAPPS_SOURCES_ALL_PATH)/vendor/pittpatt/models/detection/yaw_roll_face_detectors.7.1/pose-y-r.8.1.bin:system/vendor/pittpatt/models/detection/yaw_roll_face_detectors.7.1/pose-y-r.8.1.bin \
                       $(GAPPS_SOURCES_ALL_PATH)/vendor/pittpatt/models/detection/yaw_roll_face_detectors.7.1/pose-r.8.1.bin:system/vendor/pittpatt/models/detection/yaw_roll_face_detectors.7.1/pose-r.8.1.bin \

--- a/opengapps-packages.mk
+++ b/opengapps-packages.mk
@@ -13,18 +13,18 @@ PRODUCT_PACKAGES += GoogleBackupTransport \
                     Phonesky \
                     GoogleCalendarSyncAdapter
 
-ifneq ($(filter $(GAPPS_VARIANT),nano),) # require at least nano
+ifneq ($(filter $(TARGET_GAPPS_VARIANT),nano),) # require at least nano
 PRODUCT_PACKAGES += FaceLock \
                     Velvet
 
-ifneq ($(filter $(GAPPS_VARIANT),micro),) # require at least micro
+ifneq ($(filter $(TARGET_GAPPS_VARIANT),micro),) # require at least micro
 PRODUCT_PACKAGES += CalendarGooglePrebuilt \
                     PrebuiltExchange3Google \
                     PrebuiltGmail \
                     GoogleHome \
                     GoogleTTS
 
-ifneq ($(filter $(GAPPS_VARIANT),mini),) # require at least mini
+ifneq ($(filter $(TARGET_GAPPS_VARIANT),mini),) # require at least mini
 PRODUCT_PACKAGES += GoogleHome \
                     GoogleTTS \
                     PrebuiltDeskClockGoogle \
@@ -34,7 +34,7 @@ PRODUCT_PACKAGES += GoogleHome \
                     Photos \
                     YouTube
 
-ifneq ($(filter $(GAPPS_VARIANT),full),) # require at least full
+ifneq ($(filter $(TARGET_GAPPS_VARIANT),full),) # require at least full
 PRODUCT_PACKAGES += Books \
                     Chrome \
                     CloudPrint2 \
@@ -52,12 +52,12 @@ PRODUCT_PACKAGES += Books \
                     EditorsSlides \
                     talkback
 
-ifneq ($(filter $(GAPPS_VARIANT),stock),) # require at least stock
+ifneq ($(filter $(TARGET_GAPPS_VARIANT),stock),) # require at least stock
 PRODUCT_PACKAGES += GoogleCamera \
                     LatinImeGoogle \
                     PrebuiltBugle
 
-ifneq ($(filter $(GAPPS_VARIANT),super),)
+ifneq ($(filter $(TARGET_GAPPS_VARIANT),super),)
 
 ifeq ($(call get-allowed-api-levels),23)
 PRODUCT_PACKAGES += AndroidForWork


### PR DESCRIPTION
I just had a build issue because I was using too much space on the system partition,
since it set GAPPS_VARIANT to default "stock" when opengapps-packages.mk got imported
by the device.mk

This avoids this happening by requiring that GAPPS_VARIANT is set.

Also fix so we don't reassign a set variable (GAPPS_VARIANT) but rather move it
to a seperate variable (TARGET_GAPPS_VARIANT) that is being read.

Move the configuration variable recommendation from BoardConfig.mk -> device.mk.