### PR TITLE
Remove LOCAL_MODULE_PATH

### DIFF
--- a/modules/AndroidForWork/Android.mk
+++ b/modules/AndroidForWork/Android.mk
@@ -2,6 +2,6 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := AndroidForWork
 LOCAL_PACKAGE_NAME := com.google.android.androidforwork
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/priv-app
+LOCAL_PRIVILEGED_MODULE := true
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/Books/Android.mk
+++ b/modules/Books/Android.mk
@@ -2,6 +2,5 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := Books
 LOCAL_PACKAGE_NAME := com.google.android.apps.books
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/app
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/CalendarGooglePrebuilt/Android.mk
+++ b/modules/CalendarGooglePrebuilt/Android.mk
@@ -2,7 +2,6 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := CalendarGooglePrebuilt
 LOCAL_PACKAGE_NAME := com.google.android.calendar
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/app
 LOCAL_OVERRIDES_PACKAGES := GoogleCalendarSyncAdapter
 
 ifneq ($(filter $(TARGET_GAPPS_VARIANT),stock),) # overwrite if stock/super

--- a/modules/Chrome/Android.mk
+++ b/modules/Chrome/Android.mk
@@ -2,7 +2,6 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := Chrome
 LOCAL_PACKAGE_NAME := com.android.chrome
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/app
 
 ifneq ($(filter $(TARGET_GAPPS_VARIANT),stock),) # overwrite Browser if stock/super
 LOCAL_OVERRIDES_PACKAGES := Browser BrowserProviderProxy Chromium

--- a/modules/CloudPrint2/Android.mk
+++ b/modules/CloudPrint2/Android.mk
@@ -2,6 +2,5 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := CloudPrint2
 LOCAL_PACKAGE_NAME := com.google.android.apps.cloudprint
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/app
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/DMAgent/Android.mk
+++ b/modules/DMAgent/Android.mk
@@ -2,6 +2,5 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := DMAgent
 LOCAL_PACKAGE_NAME := com.google.android.apps.enterprise.dmagent
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/app
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/Drive/Android.mk
+++ b/modules/Drive/Android.mk
@@ -2,6 +2,5 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := Drive
 LOCAL_PACKAGE_NAME := com.google.android.apps.docs
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/app
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/EditorsDocs/Android.mk
+++ b/modules/EditorsDocs/Android.mk
@@ -2,6 +2,5 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := EditorsDocs
 LOCAL_PACKAGE_NAME := com.google.android.apps.docs.editors.docs
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/app
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/EditorsSheets/Android.mk
+++ b/modules/EditorsSheets/Android.mk
@@ -2,6 +2,5 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := EditorsSheets
 LOCAL_PACKAGE_NAME := com.google.android.apps.docs.editors.sheets
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/app
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/EditorsSlides/Android.mk
+++ b/modules/EditorsSlides/Android.mk
@@ -2,6 +2,5 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := EditorsSlides
 LOCAL_PACKAGE_NAME := com.google.android.apps.docs.editors.slides
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/app
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/FaceLock/Android.mk
+++ b/modules/FaceLock/Android.mk
@@ -2,7 +2,6 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := FaceLock
 LOCAL_PACKAGE_NAME := com.android.facelock
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/app
 LOCAL_SHARED_LIBRARIES := libfilterpack_facedetect libfacelock_jni libfrsdk
 include $(BUILD_GAPPS_PREBUILT_APK)
 

--- a/modules/GCS/Android.mk
+++ b/modules/GCS/Android.mk
@@ -2,6 +2,6 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := GCS
 LOCAL_PACKAGE_NAME := com.google.android.apps.gcs
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/priv-app
+LOCAL_PRIVILEGED_MODULE := true
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/GoogleBackupTransport/Android.mk
+++ b/modules/GoogleBackupTransport/Android.mk
@@ -2,6 +2,6 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := GoogleBackupTransport
 LOCAL_PACKAGE_NAME := com.google.android.backuptransport
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/priv-app
+LOCAL_PRIVILEGED_MODULE := true
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/GoogleCalendarSyncAdapter/Android.mk
+++ b/modules/GoogleCalendarSyncAdapter/Android.mk
@@ -2,6 +2,5 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := GoogleCalendarSyncAdapter
 LOCAL_PACKAGE_NAME := com.google.android.syncadapters.calendar
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/app
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/GoogleCamera/Android.mk
+++ b/modules/GoogleCamera/Android.mk
@@ -2,7 +2,6 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := GoogleCamera
 LOCAL_PACKAGE_NAME := com.google.android.googlecamera
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/app
 
 ifneq ($(filter $(TARGET_GAPPS_VARIANT),stock),) # overwrite if stock/super
 LOCAL_OVERRIDES_PACKAGES := Camera Camera2 MotCamera

--- a/modules/GoogleContactsSyncAdapter/Android.mk
+++ b/modules/GoogleContactsSyncAdapter/Android.mk
@@ -2,6 +2,5 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := GoogleContactsSyncAdapter
 LOCAL_PACKAGE_NAME := com.google.android.syncadapters.contacts
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/app
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/GoogleEars/Android.mk
+++ b/modules/GoogleEars/Android.mk
@@ -2,6 +2,5 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := GoogleEars
 LOCAL_PACKAGE_NAME := com.google.android.ears
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/app
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/GoogleFeedback/Android.mk
+++ b/modules/GoogleFeedback/Android.mk
@@ -2,6 +2,6 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := GoogleFeedback
 LOCAL_PACKAGE_NAME := com.google.android.feedback
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/priv-app
+LOCAL_PRIVILEGED_MODULE := true
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/GoogleHindiIME/Android.mk
+++ b/modules/GoogleHindiIME/Android.mk
@@ -2,6 +2,5 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := GoogleHindiIME
 LOCAL_PACKAGE_NAME := com.google.android.apps.inputmethod.hindi
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/app
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/GoogleHome/Android.mk
+++ b/modules/GoogleHome/Android.mk
@@ -2,6 +2,5 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := GoogleHome
 LOCAL_PACKAGE_NAME := com.google.android.launcher
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/app
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/GoogleJapaneseInput/Android.mk
+++ b/modules/GoogleJapaneseInput/Android.mk
@@ -2,6 +2,5 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := GoogleJapaneseInput
 LOCAL_PACKAGE_NAME := com.google.android.inputmethod.japanese
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/app
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/GoogleLoginService/Android.mk
+++ b/modules/GoogleLoginService/Android.mk
@@ -2,6 +2,6 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := GoogleLoginService
 LOCAL_PACKAGE_NAME := com.google.android.gsf.login
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/priv-app
+LOCAL_PRIVILEGED_MODULE := true
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/GoogleOneTimeInitializer/Android.mk
+++ b/modules/GoogleOneTimeInitializer/Android.mk
@@ -2,6 +2,6 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := GoogleOneTimeInitializer
 LOCAL_PACKAGE_NAME := com.google.android.onetimeinitializer
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/priv-app
+LOCAL_PRIVILEGED_MODULE := true
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/GooglePartnerSetup/Android.mk
+++ b/modules/GooglePartnerSetup/Android.mk
@@ -2,6 +2,6 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := GooglePartnerSetup
 LOCAL_PACKAGE_NAME := com.google.android.partnersetup
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/priv-app
+LOCAL_PRIVILEGED_MODULE := true
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/GooglePinyinIME/Android.mk
+++ b/modules/GooglePinyinIME/Android.mk
@@ -2,6 +2,5 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := GooglePinyinIME
 LOCAL_PACKAGE_NAME := com.google.android.inputmethod.pinyin
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/app
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/GoogleServicesFramework/Android.mk
+++ b/modules/GoogleServicesFramework/Android.mk
@@ -2,6 +2,6 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := GoogleServicesFramework
 LOCAL_PACKAGE_NAME := com.google.android.gsf
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/priv-app
+LOCAL_PRIVILEGED_MODULE := true
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/GoogleTTS/Android.mk
+++ b/modules/GoogleTTS/Android.mk
@@ -2,6 +2,5 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := GoogleTTS
 LOCAL_PACKAGE_NAME := com.google.android.tts
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/app
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/GoogleZhuyinIME/Android.mk
+++ b/modules/GoogleZhuyinIME/Android.mk
@@ -2,6 +2,5 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := GoogleZhuyinIME
 LOCAL_PACKAGE_NAME := com.google.android.apps.inputmethod.zhuyin
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/app
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/Hangouts/Android.mk
+++ b/modules/Hangouts/Android.mk
@@ -2,6 +2,5 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := Hangouts
 LOCAL_PACKAGE_NAME := com.google.android.talk
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/app
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/KoreanIME/Android.mk
+++ b/modules/KoreanIME/Android.mk
@@ -2,6 +2,5 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := KoreanIME
 LOCAL_PACKAGE_NAME := com.google.android.inputmethod.korean
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/app
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/LatinImeGoogle/Android.mk
+++ b/modules/LatinImeGoogle/Android.mk
@@ -2,7 +2,6 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := LatinImeGoogle
 LOCAL_PACKAGE_NAME := com.google.android.inputmethod.latin
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/app
 
 ifneq ($(filter $(TARGET_GAPPS_VARIANT),stock),) # overwrite if stock/super
 LOCAL_OVERRIDES_PACKAGES := LatinIME

--- a/modules/Maps/Android.mk
+++ b/modules/Maps/Android.mk
@@ -2,6 +2,5 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := Maps
 LOCAL_PACKAGE_NAME := com.google.android.apps.maps
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/app
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/Music2/Android.mk
+++ b/modules/Music2/Android.mk
@@ -2,6 +2,5 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := Music2
 LOCAL_PACKAGE_NAME := com.google.android.music
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/app
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/Newsstand/Android.mk
+++ b/modules/Newsstand/Android.mk
@@ -2,6 +2,5 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := Newsstand
 LOCAL_PACKAGE_NAME := com.google.android.apps.magazines
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/app
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/Phonesky/Android.mk
+++ b/modules/Phonesky/Android.mk
@@ -2,6 +2,6 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := Phonesky
 LOCAL_PACKAGE_NAME := com.android.vending
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/priv-app
+LOCAL_PRIVILEGED_MODULE := true
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/Photos/Android.mk
+++ b/modules/Photos/Android.mk
@@ -2,7 +2,6 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := Photos
 LOCAL_PACKAGE_NAME := com.google.android.apps.photos
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/app
 
 ifneq ($(filter $(TARGET_GAPPS_VARIANT),stock),) # overwrite if stock/super
 LOCAL_OVERRIDES_PACKAGES := Gallery Gallery2 MotGallery MediaShortcuts

--- a/modules/PlayGames/Android.mk
+++ b/modules/PlayGames/Android.mk
@@ -2,6 +2,5 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := PlayGames
 LOCAL_PACKAGE_NAME := com.google.android.play.games
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/app
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/PlusOne/Android.mk
+++ b/modules/PlusOne/Android.mk
@@ -2,6 +2,5 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := PlusOne
 LOCAL_PACKAGE_NAME := com.google.android.apps.plus
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/app
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/PrebuiltBugle/Android.mk
+++ b/modules/PrebuiltBugle/Android.mk
@@ -2,7 +2,6 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := PrebuiltBugle
 LOCAL_PACKAGE_NAME := com.google.android.apps.messaging
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/app
 
 ifneq ($(filter $(TARGET_GAPPS_VARIANT),stock),) # overwrite if stock/super
 LOCAL_OVERRIDES_PACKAGES := messaging Mms

--- a/modules/PrebuiltDeskClockGoogle/Android.mk
+++ b/modules/PrebuiltDeskClockGoogle/Android.mk
@@ -2,7 +2,6 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := PrebuiltDeskClockGoogle
 LOCAL_PACKAGE_NAME := com.google.android.deskclock
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/app
 
 ifneq ($(filter $(TARGET_GAPPS_VARIANT),stock),) # overwrite if stock/super
 LOCAL_OVERRIDES_PACKAGES := DeskClock

--- a/modules/PrebuiltExchange3Google/Android.mk
+++ b/modules/PrebuiltExchange3Google/Android.mk
@@ -2,7 +2,6 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := PrebuiltExchange3Google
 LOCAL_PACKAGE_NAME := com.google.android.gm.exchange
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/app
 
 LOCAL_OVERRIDES_PACKAGES := Exchange2
 

--- a/modules/PrebuiltGmail/Android.mk
+++ b/modules/PrebuiltGmail/Android.mk
@@ -2,7 +2,6 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := PrebuiltGmail
 LOCAL_PACKAGE_NAME := com.google.android.gm
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/app
 
 ifneq ($(filter $(TARGET_GAPPS_VARIANT),stock),) # overwrite if stock/super
 LOCAL_OVERRIDES_PACKAGES := Email

--- a/modules/PrebuiltGmsCore/Android.mk
+++ b/modules/PrebuiltGmsCore/Android.mk
@@ -2,6 +2,6 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := PrebuiltGmsCore
 LOCAL_PACKAGE_NAME := com.google.android.gms
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/priv-app
+LOCAL_PRIVILEGED_MODULE := true
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/PrebuiltKeep/Android.mk
+++ b/modules/PrebuiltKeep/Android.mk
@@ -2,6 +2,5 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := PrebuiltKeep
 LOCAL_PACKAGE_NAME := com.google.android.keep
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/app
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/PrebuiltNewsWeather/Android.mk
+++ b/modules/PrebuiltNewsWeather/Android.mk
@@ -2,6 +2,5 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := PrebuiltNewsWeather
 LOCAL_PACKAGE_NAME := com.google.android.apps.genie.geniewidget
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/app
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/SetupWizard/Android.mk
+++ b/modules/SetupWizard/Android.mk
@@ -2,6 +2,6 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := SetupWizard
 LOCAL_PACKAGE_NAME := com.google.android.setupwizard
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/priv-app
+LOCAL_PRIVILEGED_MODULE := true
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/Street/Android.mk
+++ b/modules/Street/Android.mk
@@ -2,6 +2,5 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := Street
 LOCAL_PACKAGE_NAME := com.google.android.street
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/app
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/TranslatePrebuilt/Android.mk
+++ b/modules/TranslatePrebuilt/Android.mk
@@ -2,6 +2,5 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := TranslatePrebuilt
 LOCAL_PACKAGE_NAME := com.google.android.apps.translate
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/app
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/Velvet/Android.mk
+++ b/modules/Velvet/Android.mk
@@ -2,7 +2,7 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := Velvet
 LOCAL_PACKAGE_NAME := com.google.android.googlequicksearchbox
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/priv-app
+LOCAL_PRIVILEGED_MODULE := true
 
 LOCAL_OVERRIDES_PACKAGES := QuickSearchBox
 

--- a/modules/Videos/Android.mk
+++ b/modules/Videos/Android.mk
@@ -2,6 +2,5 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := Videos
 LOCAL_PACKAGE_NAME := com.google.android.videos
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/app
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/Wallet/Android.mk
+++ b/modules/Wallet/Android.mk
@@ -2,6 +2,5 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := Wallet
 LOCAL_PACKAGE_NAME := com.google.android.apps.walletnfcrel
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/app
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/WebViewGoogle/Android.mk
+++ b/modules/WebViewGoogle/Android.mk
@@ -2,7 +2,6 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := WebViewGoogle
 LOCAL_PACKAGE_NAME := com.google.android.webview
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/app
 
 LOCAL_OVERRIDES_PACKAGES := webview
 

--- a/modules/YouTube/Android.mk
+++ b/modules/YouTube/Android.mk
@@ -2,6 +2,5 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := YouTube
 LOCAL_PACKAGE_NAME := com.google.android.youtube
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/app
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/talkback/Android.mk
+++ b/modules/talkback/Android.mk
@@ -2,6 +2,5 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 LOCAL_MODULE := talkback
 LOCAL_PACKAGE_NAME := com.google.android.marvin.talkback
-LOCAL_MODULE_PATH := $(PRODUCT_OUT)/system/app
 
 include $(BUILD_GAPPS_PREBUILT_APK)


### PR DESCRIPTION
LOCAL_MODULE_PATH was actually not needed. We just need to make sure
to mark applications that we want in /system/priv-app with
LOCAL_PRIVILEGED_MODULE.

APPS gets, by default, installed in /system/app