### PR TITLE
Fix WebView dependencies.

### DIFF
--- a/modules/WebViewGoogle/Android.mk
+++ b/modules/WebViewGoogle/Android.mk
@@ -5,4 +5,7 @@ LOCAL_PACKAGE_NAME := com.google.android.webview
 
 LOCAL_OVERRIDES_PACKAGES := webview
 
+LOCAL_REQUIRED_MODULES := libwebviewchromium_loader \
+                          libwebviewchromium_plat_support
+
 include $(BUILD_GAPPS_PREBUILT_APK)


### PR DESCRIPTION
WebView requires libwebviewchromium_loader and libwebviewchromium_plat_support libraries.

When overriding aosp WebView, those librares are missing.
This causes most gapps and other apps using the WebView to crash.
Adding them to LOCAL_REQUIRED_MODULES will fix this issue.