### PR TITLE
Minor code refactoring

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -26,12 +26,12 @@ include $(GAPPS_BUILD_SYSTEM_PATH)/definitions.mk
 
 # Device should define their GAPPS_VARIANT in device/manufacturer/product/BoardConfig.mk
 ifeq ($(GAPPS_VARIANT),)
-	$(error GAPPS_VARIANT must be configured)
+  $(error GAPPS_VARIANT must be configured)
 endif
 GAPPS_VARIANT_EVAL := $(call get-gapps-variant,$(GAPPS_VARIANT))
 
 ifeq ($(GAPPS_VARIANT_EVAL),)
-$(error GAPPS_VARIANT $(GAPPS_VARIANT) was not found. Use of one of pico,nano,micro,mini,full,stock,super)
+  $(error GAPPS_VARIANT $(GAPPS_VARIANT) was not found. Use of one of pico,nano,micro,mini,full,stock,super)
 endif
 
 TARGET_GAPPS_VARIANT := $(GAPPS_VARIANT_EVAL)

--- a/core/definitions.mk
+++ b/core/definitions.mk
@@ -1,13 +1,13 @@
 define get-allowed-api-levels
-$(shell seq 1 $(PLATFORM_SDK_VERSION))
+$(shell seq 1 "$(PLATFORM_SDK_VERSION)")
 endef
 
 define get-allowed-api-levels-regex
-($(call subst, ,|,$(call get-allowed-api-levels)))
+($(call subst,,|,$(call get-allowed-api-levels)))
 endef
 
 define find-apk-for-pkg
-$(shell $(GAPPS_BUILD_SYSTEM_PATH)/find_apk.sh "$(GAPPS_SOURCES_PATH)" $(PLATFORM_SDK_VERSION) $(PRODUCT_AAPT_PREF_CONFIG) $(2) $(1) $(GAPPS_FORCE_MATCHING_DPI) $(GAPPS_AAPT_PATH))
+$(shell "$(GAPPS_BUILD_SYSTEM_PATH)/find_apk.sh" "$(GAPPS_SOURCES_PATH)" "$(PLATFORM_SDK_VERSION)" "$(PRODUCT_AAPT_PREF_CONFIG)" "$(2)" "$(1)" "$(GAPPS_FORCE_MATCHING_DPI)" "$(GAPPS_AAPT_PATH)")
 endef
 
 define get-lib-search-path
@@ -15,7 +15,7 @@ $(if $(filter $(1),arm),lib/armeabi*/*,lib/$(1)*/*)
 endef
 
 define find-libs-in-apk
-$(addprefix @,$(shell zipinfo -1 $(2) | grep "$(call get-lib-search-path, $(1))" | grep -v -E "*/crazy.*"))
+$(addprefix @,$(shell zipinfo -1 "$(2)" | grep "$(call get-lib-search-path, $(1))" | grep -v -E "*/crazy.*"))
 endef
 
 define get-gapps-variant
@@ -32,22 +32,22 @@ endef
 
 define _gapps-all-files-under
 $(patsubst ./%,%, \
-	$(shell cd $(GAPPS_SOURCES_PATH); cd $(1); \
+	$(shell cd "$(GAPPS_SOURCES_PATH)"; cd "$(1)"; \
 		find -L $(2) -type f -and -not -name ".*") \
 )
 endef
 
 define gapps-copy-to-system
-$(foreach F,$(call _gapps-all-files-under, $(1), $(2)),$(join $(GAPPS_SOURCES_PATH)/,$(1))/$F:system/$F)
+$(foreach F,$(call _gapps-all-files-under,$(1),$(2)),$(join $(GAPPS_SOURCES_PATH)/,$(1))/$F:system/$F)
 endef
 
 define _gapps-find-lib-alternatives
-$(foreach F,$(call get-allowed-api-levels), $(join $(join $(1)/,$F)/,$(2)))
+$(foreach F,$(call get-allowed-api-levels),$(join $(join $(1)/,$F)/,$(2)))
 endef
 
 define gapps-find-lib-for-arch
-$(join $(GAPPS_SOURCES_PATH)/,$(shell cd $(GAPPS_SOURCES_PATH); \
-	find -L $(call _gapps-find-lib-alternatives, $(join $(1)/,$(2)), $(3)) 2>/dev/null | tail -n1))
+$(join $(GAPPS_SOURCES_PATH)/,$(shell cd "$(GAPPS_SOURCES_PATH)"; \
+	find -L $(call _gapps-find-lib-alternatives,$(join $(1)/,$(2)),$(3)) 2>/dev/null | tail -n1))
 endef
 
 BUILD_GAPPS_PREBUILT_APK := $(GAPPS_BUILD_SYSTEM_PATH)/prebuilt_apk.mk

--- a/core/prebuilt_shared_library.mk
+++ b/core/prebuilt_shared_library.mk
@@ -3,32 +3,32 @@ LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE_SUFFIX := $(TARGET_SHLIB_SUFFIX)
 
 ifeq ($(GAPPS_IS_VENDOR_LIB),true)
-lib_prefix := vendor/
+  lib_prefix := vendor/
 endif
 
 ifdef TARGET_2ND_ARCH
-LOCAL_MULTILIB ?= both
-ifeq ($(GAPPS_IS_VENDOR_LIB), true)
-LOCAL_MODULE_PATH_64 := $(TARGET_OUT_VENDOR_SHARED_LIBRARIES)
-LOCAL_MODULE_PATH_32 := $($(TARGET_2ND_ARCH_VAR_PREFIX)TARGET_OUT_VENDOR_SHARED_LIBRARIES)
+  LOCAL_MULTILIB ?= both
+  ifeq ($(GAPPS_IS_VENDOR_LIB),true)
+    LOCAL_MODULE_PATH_64 := $(TARGET_OUT_VENDOR_SHARED_LIBRARIES)
+    LOCAL_MODULE_PATH_32 := $($(TARGET_2ND_ARCH_VAR_PREFIX)TARGET_OUT_VENDOR_SHARED_LIBRARIES)
+  else
+    LOCAL_MODULE_PATH_64 := $(TARGET_OUT_SHARED_LIBRARIES)
+    LOCAL_MODULE_PATH_32 := $($(TARGET_2ND_ARCH_VAR_PREFIX)TARGET_OUT_SHARED_LIBRARIES)
+  endif # GAPPS_IS_VENDOR_LIB
 else
-LOCAL_MODULE_PATH_64 := $(TARGET_OUT_SHARED_LIBRARIES)
-LOCAL_MODULE_PATH_32 := $($(TARGET_2ND_ARCH_VAR_PREFIX)TARGET_OUT_SHARED_LIBRARIES)
-endif # GAPPS_IS_VENDOR_LIB
-else
-ifeq ($(GAPPS_IS_VENDOR_LIB), true)
-LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR_SHARED_LIBRARIES)
-else
-LOCAL_MODULE_PATH := $(TARGET_OUT_SHARED_LIBRARIES)
-endif # GAPPS_IS_VENDOR_LIB
+  ifeq ($(GAPPS_IS_VENDOR_LIB),true)
+    LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR_SHARED_LIBRARIES)
+  else
+    LOCAL_MODULE_PATH := $(TARGET_OUT_SHARED_LIBRARIES)
+  endif # GAPPS_IS_VENDOR_LIB
 endif # TARGET_2ND_ARCH
 
 full_name := $(LOCAL_MODULE)$(LOCAL_MODULE_SUFFIX)
 ifdef TARGET_2ND_ARCH
-LOCAL_SRC_FILES_64 := $(call gapps-find-lib-for-arch, $(TARGET_ARCH), $(lib_prefix)lib64, $(full_name))
-LOCAL_SRC_FILES_32 := $(call gapps-find-lib-for-arch, $(TARGET_2ND_ARCH), $(lib_prefix)lib, $(full_name))
+  LOCAL_SRC_FILES_64 := $(call gapps-find-lib-for-arch,$(TARGET_ARCH),$(lib_prefix)lib64,$(full_name))
+  LOCAL_SRC_FILES_32 := $(call gapps-find-lib-for-arch,$(TARGET_2ND_ARCH),$(lib_prefix)lib,$(full_name))
 else
-LOCAL_SRC_FILES := $(call gapps-find-lib-for-arch, $(TARGET_ARCH), $(lib_prefix)lib, $(full_name))
+  LOCAL_SRC_FILES := $(call gapps-find-lib-for-arch,$(TARGET_ARCH),$(lib_prefix)lib,$(full_name))
 endif
 
 # Reset internal variables

--- a/opengapps-files.mk
+++ b/opengapps-files.mk
@@ -1,7 +1,7 @@
 # Always needed
-PRODUCT_COPY_FILES += $(call gapps-copy-to-system, all, etc framework)
+PRODUCT_COPY_FILES += $(call gapps-copy-to-system,all,etc framework)
 
 # Pico and higher
 ifneq ($(filter $(TARGET_GAPPS_VARIANT),pico),)
-PRODUCT_COPY_FILES += $(call gapps-copy-to-system, all, vendor/pittpatt usr/srec)
+  PRODUCT_COPY_FILES += $(call gapps-copy-to-system,all,vendor/pittpatt usr/srec)
 endif


### PR DESCRIPTION
Quote all shell variables, except when required not to (eg: after find -L)
Trim spaces in makefile function arguments to maintain compatibility with shell commands while maintaining a consistent code style.
Use consistent indentation.

resolves #29 