### PR TITLE
Avoid too many open files error

### DIFF
--- a/core/clear_vars.mk
+++ b/core/clear_vars.mk
@@ -1,5 +1,3 @@
-include $(CLEAR_VARS)
-
 # Reset custom local variables.
 GAPPS_LOCAL_OVERRIDES_PACKAGES :=
 GAPPS_LOCAL_OVERRIDES_MIN_VARIANT :=

--- a/modules/AndroidForWork/Android.mk
+++ b/modules/AndroidForWork/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := AndroidForWork
 LOCAL_PACKAGE_NAME := com.google.android.androidforwork

--- a/modules/Books/Android.mk
+++ b/modules/Books/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := Books
 LOCAL_PACKAGE_NAME := com.google.android.apps.books

--- a/modules/CalculatorGoogle/Android.mk
+++ b/modules/CalculatorGoogle/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := CalculatorGoogle
 LOCAL_PACKAGE_NAME := com.google.android.calculator

--- a/modules/CalendarGooglePrebuilt/Android.mk
+++ b/modules/CalendarGooglePrebuilt/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := CalendarGooglePrebuilt
 LOCAL_PACKAGE_NAME := com.google.android.calendar

--- a/modules/Chrome/Android.mk
+++ b/modules/Chrome/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := Chrome
 LOCAL_PACKAGE_NAME := com.android.chrome

--- a/modules/CloudPrint2/Android.mk
+++ b/modules/CloudPrint2/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := CloudPrint2
 LOCAL_PACKAGE_NAME := com.google.android.apps.cloudprint

--- a/modules/DMAgent/Android.mk
+++ b/modules/DMAgent/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := DMAgent
 LOCAL_PACKAGE_NAME := com.google.android.apps.enterprise.dmagent

--- a/modules/Drive/Android.mk
+++ b/modules/Drive/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := Drive
 LOCAL_PACKAGE_NAME := com.google.android.apps.docs

--- a/modules/EditorsDocs/Android.mk
+++ b/modules/EditorsDocs/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := EditorsDocs
 LOCAL_PACKAGE_NAME := com.google.android.apps.docs.editors.docs

--- a/modules/EditorsSheets/Android.mk
+++ b/modules/EditorsSheets/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := EditorsSheets
 LOCAL_PACKAGE_NAME := com.google.android.apps.docs.editors.sheets

--- a/modules/EditorsSlides/Android.mk
+++ b/modules/EditorsSlides/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := EditorsSlides
 LOCAL_PACKAGE_NAME := com.google.android.apps.docs.editors.slides

--- a/modules/FaceLock/Android.mk
+++ b/modules/FaceLock/Android.mk
@@ -1,18 +1,22 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := FaceLock
 LOCAL_PACKAGE_NAME := com.android.facelock
 LOCAL_SHARED_LIBRARIES := libfilterpack_facedetect libfacelock_jni libfrsdk
 include $(BUILD_GAPPS_PREBUILT_APK)
 
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := libfilterpack_facedetect
 include $(BUILD_GAPPS_PREBUILT_SHARED_LIBRARY)
 
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := libfacelock_jni
 include $(BUILD_GAPPS_PREBUILT_SHARED_LIBRARY)
 
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := libfrsdk
 GAPPS_IS_VENDOR_LIB := true

--- a/modules/GCS/Android.mk
+++ b/modules/GCS/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := GCS
 LOCAL_PACKAGE_NAME := com.google.android.apps.gcs

--- a/modules/GoogleBackupTransport/Android.mk
+++ b/modules/GoogleBackupTransport/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := GoogleBackupTransport
 LOCAL_PACKAGE_NAME := com.google.android.backuptransport

--- a/modules/GoogleCalendarSyncAdapter/Android.mk
+++ b/modules/GoogleCalendarSyncAdapter/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := GoogleCalendarSyncAdapter
 LOCAL_PACKAGE_NAME := com.google.android.syncadapters.calendar

--- a/modules/GoogleCamera/Android.mk
+++ b/modules/GoogleCamera/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := GoogleCamera
 LOCAL_PACKAGE_NAME := com.google.android.googlecamera

--- a/modules/GoogleContacts/Android.mk
+++ b/modules/GoogleContacts/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := GoogleContacts
 LOCAL_PACKAGE_NAME := com.google.android.contacts

--- a/modules/GoogleContactsSyncAdapter/Android.mk
+++ b/modules/GoogleContactsSyncAdapter/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := GoogleContactsSyncAdapter
 LOCAL_PACKAGE_NAME := com.google.android.syncadapters.contacts

--- a/modules/GoogleDialer/Android.mk
+++ b/modules/GoogleDialer/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := GoogleDialer
 LOCAL_PACKAGE_NAME := com.google.android.dialer

--- a/modules/GoogleEars/Android.mk
+++ b/modules/GoogleEars/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := GoogleEars
 LOCAL_PACKAGE_NAME := com.google.android.ears

--- a/modules/GoogleFeedback/Android.mk
+++ b/modules/GoogleFeedback/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := GoogleFeedback
 LOCAL_PACKAGE_NAME := com.google.android.feedback

--- a/modules/GoogleHindiIME/Android.mk
+++ b/modules/GoogleHindiIME/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := GoogleHindiIME
 LOCAL_PACKAGE_NAME := com.google.android.apps.inputmethod.hindi

--- a/modules/GoogleHome/Android.mk
+++ b/modules/GoogleHome/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := GoogleHome
 LOCAL_PACKAGE_NAME := com.google.android.launcher

--- a/modules/GoogleJapaneseInput/Android.mk
+++ b/modules/GoogleJapaneseInput/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := GoogleJapaneseInput
 LOCAL_PACKAGE_NAME := com.google.android.inputmethod.japanese

--- a/modules/GoogleLoginService/Android.mk
+++ b/modules/GoogleLoginService/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := GoogleLoginService
 LOCAL_PACKAGE_NAME := com.google.android.gsf.login

--- a/modules/GoogleOneTimeInitializer/Android.mk
+++ b/modules/GoogleOneTimeInitializer/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := GoogleOneTimeInitializer
 LOCAL_PACKAGE_NAME := com.google.android.onetimeinitializer

--- a/modules/GooglePartnerSetup/Android.mk
+++ b/modules/GooglePartnerSetup/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := GooglePartnerSetup
 LOCAL_PACKAGE_NAME := com.google.android.partnersetup

--- a/modules/GooglePinyinIME/Android.mk
+++ b/modules/GooglePinyinIME/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := GooglePinyinIME
 LOCAL_PACKAGE_NAME := com.google.android.inputmethod.pinyin

--- a/modules/GoogleServicesFramework/Android.mk
+++ b/modules/GoogleServicesFramework/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := GoogleServicesFramework
 LOCAL_PACKAGE_NAME := com.google.android.gsf

--- a/modules/GoogleTTS/Android.mk
+++ b/modules/GoogleTTS/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := GoogleTTS
 LOCAL_PACKAGE_NAME := com.google.android.tts

--- a/modules/GoogleZhuyinIME/Android.mk
+++ b/modules/GoogleZhuyinIME/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := GoogleZhuyinIME
 LOCAL_PACKAGE_NAME := com.google.android.apps.inputmethod.zhuyin

--- a/modules/Hangouts/Android.mk
+++ b/modules/Hangouts/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := Hangouts
 LOCAL_PACKAGE_NAME := com.google.android.talk

--- a/modules/HotwordEnrollment/Android.mk
+++ b/modules/HotwordEnrollment/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := Hotword
 LOCAL_PACKAGE_NAME := com.android.hotwordenrollment

--- a/modules/KoreanIME/Android.mk
+++ b/modules/KoreanIME/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := KoreanIME
 LOCAL_PACKAGE_NAME := com.google.android.inputmethod.korean

--- a/modules/LatinImeGoogle/Android.mk
+++ b/modules/LatinImeGoogle/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := LatinImeGoogle
 LOCAL_PACKAGE_NAME := com.google.android.inputmethod.latin

--- a/modules/Maps/Android.mk
+++ b/modules/Maps/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := Maps
 LOCAL_PACKAGE_NAME := com.google.android.apps.maps

--- a/modules/Music2/Android.mk
+++ b/modules/Music2/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := Music2
 LOCAL_PACKAGE_NAME := com.google.android.music

--- a/modules/Newsstand/Android.mk
+++ b/modules/Newsstand/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := Newsstand
 LOCAL_PACKAGE_NAME := com.google.android.apps.magazines

--- a/modules/Phonesky/Android.mk
+++ b/modules/Phonesky/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := Phonesky
 LOCAL_PACKAGE_NAME := com.android.vending

--- a/modules/Photos/Android.mk
+++ b/modules/Photos/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := Photos
 LOCAL_PACKAGE_NAME := com.google.android.apps.photos

--- a/modules/PlayGames/Android.mk
+++ b/modules/PlayGames/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := PlayGames
 LOCAL_PACKAGE_NAME := com.google.android.play.games

--- a/modules/PlusOne/Android.mk
+++ b/modules/PlusOne/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := PlusOne
 LOCAL_PACKAGE_NAME := com.google.android.apps.plus

--- a/modules/PrebuiltBugle/Android.mk
+++ b/modules/PrebuiltBugle/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := PrebuiltBugle
 LOCAL_PACKAGE_NAME := com.google.android.apps.messaging

--- a/modules/PrebuiltDeskClockGoogle/Android.mk
+++ b/modules/PrebuiltDeskClockGoogle/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := PrebuiltDeskClockGoogle
 LOCAL_PACKAGE_NAME := com.google.android.deskclock

--- a/modules/PrebuiltExchange3Google/Android.mk
+++ b/modules/PrebuiltExchange3Google/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := PrebuiltExchange3Google
 LOCAL_PACKAGE_NAME := com.google.android.gm.exchange

--- a/modules/PrebuiltGmail/Android.mk
+++ b/modules/PrebuiltGmail/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := PrebuiltGmail
 LOCAL_PACKAGE_NAME := com.google.android.gm

--- a/modules/PrebuiltGmsCore/Android.mk
+++ b/modules/PrebuiltGmsCore/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := PrebuiltGmsCore
 LOCAL_PACKAGE_NAME := com.google.android.gms

--- a/modules/PrebuiltKeep/Android.mk
+++ b/modules/PrebuiltKeep/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := PrebuiltKeep
 LOCAL_PACKAGE_NAME := com.google.android.keep

--- a/modules/PrebuiltNewsWeather/Android.mk
+++ b/modules/PrebuiltNewsWeather/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := PrebuiltNewsWeather
 LOCAL_PACKAGE_NAME := com.google.android.apps.genie.geniewidget

--- a/modules/SetupWizard/Android.mk
+++ b/modules/SetupWizard/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := SetupWizard
 LOCAL_PACKAGE_NAME := com.google.android.setupwizard

--- a/modules/Street/Android.mk
+++ b/modules/Street/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := Street
 LOCAL_PACKAGE_NAME := com.google.android.street

--- a/modules/TagGoogle/Android.mk
+++ b/modules/TagGoogle/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := TagGoogle
 LOCAL_PACKAGE_NAME := com.google.android.tag

--- a/modules/TranslatePrebuilt/Android.mk
+++ b/modules/TranslatePrebuilt/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := TranslatePrebuilt
 LOCAL_PACKAGE_NAME := com.google.android.apps.translate

--- a/modules/Velvet/Android.mk
+++ b/modules/Velvet/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := Velvet
 LOCAL_PACKAGE_NAME := com.google.android.googlequicksearchbox

--- a/modules/Videos/Android.mk
+++ b/modules/Videos/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := Videos
 LOCAL_PACKAGE_NAME := com.google.android.videos

--- a/modules/Wallet/Android.mk
+++ b/modules/Wallet/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := Wallet
 LOCAL_PACKAGE_NAME := com.google.android.apps.walletnfcrel

--- a/modules/WebViewGoogle/Android.mk
+++ b/modules/WebViewGoogle/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := WebViewGoogle
 LOCAL_PACKAGE_NAME := com.google.android.webview

--- a/modules/YouTube/Android.mk
+++ b/modules/YouTube/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := YouTube
 LOCAL_PACKAGE_NAME := com.google.android.youtube

--- a/modules/talkback/Android.mk
+++ b/modules/talkback/Android.mk
@@ -1,4 +1,5 @@
 LOCAL_PATH := .
+include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := talkback
 LOCAL_PACKAGE_NAME := com.google.android.marvin.talkback


### PR DESCRIPTION
Including CLEAR_VARS inside GAPPS_CLEAR_VARS seems to cause issues on some builds.
This separates the two files to solve the issue.