### PR TITLE
Configure network location provider overlay for all types

### DIFF
--- a/opengapps-packages.mk
+++ b/opengapps-packages.mk
@@ -1,6 +1,8 @@
 include vendor/google/build/config.mk
 include $(GAPPS_FILES)
 
+DEVICE_PACKAGE_OVERLAYS += $(GAPPS_DEVICE_FILES_PATH)/overlay/pico
+
 PRODUCT_PACKAGES += GoogleBackupTransport \
                     GoogleContactsSyncAdapter \
                     GoogleFeedback \

--- a/overlay/pico/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/pico/frameworks/base/core/res/res/values/config.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+** Copyright 2011, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<!-- These resources are around just to allow their values to be customized
+     for different hardware and product builds. -->
+<resources>
+    <!-- Enable overlay for all location components. -->
+    <bool name="config_enableNetworkLocationOverlay" translatable="false">true</bool>
+    <bool name="config_enableFusedLocationOverlay" translatable="false">true</bool>
+    <bool name="config_enableGeocoderOverlay" translatable="false">true</bool>
+    <bool name="config_enableGeofenceOverlay" translatable="false">true</bool>
+    <!--
+       Sets the package names whose certificates should be used to
+       verify location providers are allowed to be loaded.
+    -->
+    <string-array name="config_locationProviderPackageNames" translatable="false">
+        <item>com.google.android.gms</item>
+        <item>com.android.location.fused</item>
+    </string-array>
+</resources>


### PR DESCRIPTION
The network location provider must be configured in the XML for all
device types, otherwise issues occur on 6.0+ with permissions, and
on all devices with the network location provider.

I'm not sure how this will go in CyanogenMod builds since there
vendor/cm already defines a similar overlay...It should go OK thought.

This should fix #12 and #35