### PR TITLE
Reorganize files to allow placing the repository anywhere.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### Disclaimer
 1. *Use this at your own risk.* Cyanogenmod received a cease and desist letter from Google when they included Google Apps in their ROM. See: [A Note on Google Apps for Android](http://android-developers.blogspot.com/2009/09/note-on-google-apps-for-android.html)
-2. While this project places code in `vendor/google/build`, **This project is in no way affiliated with, sponsored by, or related to Google.** Placement of code in `vendor/google/build` is only done because it is required by the AOSP build process (more on that later).
+2. **This project is in no way affiliated with, sponsored by, or related to Google.**
 
 ## Getting started
 **1. Add the build system, and the wanted sources to your manifest.**
@@ -13,7 +13,7 @@ and add the following towards the end:
 ```xml
 <remote name="opengapps" fetch="https://github.com/opengapps/"  />
 
-<project path="vendor/google/build" name="aosp_build" revision="master" remote="opengapps" />
+<project path="vendor/opengapps/build" name="aosp_build" revision="master" remote="opengapps" />
 <project path="vendor/opengapps/sources/all" name="all" clone-depth="1" revision="master" remote="opengapps" />
 <!-- If you need other/additional targets, follow the same template: -->
 <project path="vendor/opengapps/sources/arm" name="arm" clone-depth="1" revision="master" remote="opengapps" />
@@ -38,7 +38,7 @@ The `opengapps-packages.mk` file will make the Android build system build the ne
 
 In `device/manufacturer/product/device.mk` file, towards the end, add:
 ```makefile
-$(call inherit-product, vendor/google/build/opengapps-packages.mk)
+$(call inherit-product, vendor/opengapps/build/opengapps.mk)
 ```
 
 **4. Build Android**
@@ -53,7 +53,7 @@ In your `device/manufacturer/product/device.mk` just add, for example:
 PRODUCT_PACKAGES += Chrome
 ```
 
-This uses the module name. You can find the module name for a package by checking `vendor/google/build/modules/` and look at the `LOCAL_MODULE` value.
+This uses the module name. You can find the module name for a package by checking `vendor/opengapps/build/modules/` and look at the `LOCAL_MODULE` value.
 
 ### Force stock package overrides
 You can force GApps packages to override the stock packages.
@@ -107,13 +107,8 @@ DONT_DEXPREOPT_PREBUILTS := true
 ```
 
 ## How it works
-The OpenGApps AOSP based build system is placed in `vendor/google/build` and includes a file called `config.mk`. This is loaded by the AOSP build system very early, and allows us to define the necessary "functions" and build targets.
-
-in `build/core/main.mk`:
-```
-# Include the google-specific config
--include vendor/google/build/config.mk
-```
+The OpenGApps AOSP based build system is placed in `vendor/opengapps/build` and includes a file called `opengapps.mk`.
+By including this in our device.mk file, this allows us to define the necessary "functions" and build targets.
 
 We use this hook to define two targets:
 ```

--- a/opengapps-packages.mk
+++ b/opengapps-packages.mk
@@ -1,6 +1,3 @@
-include vendor/google/build/config.mk
-include $(GAPPS_FILES)
-
 DEVICE_PACKAGE_OVERLAYS += $(GAPPS_DEVICE_FILES_PATH)/overlay/pico
 
 PRODUCT_PACKAGES += GoogleBackupTransport \

--- a/opengapps.mk
+++ b/opengapps.mk
@@ -1,13 +1,9 @@
 # Opengapps AOSP build system
-GAPPS_BUILD_SYSTEM_PATH := vendor/google/build/core
-GAPPS_SOURCES_PATH := vendor/opengapps/sources
-GAPPS_DEVICE_FILES_PATH := vendor/google/build
-GAPPS_FILES := $(GAPPS_DEVICE_FILES_PATH)/opengapps-files.mk
+GAPPS_DEVICE_FILES_PATH := $(LOCAL_PATH)
+GAPPS_BUILD_SYSTEM_PATH := $(GAPPS_DEVICE_FILES_PATH)/core
 GAPPS_CLEAR_VARS := $(GAPPS_BUILD_SYSTEM_PATH)/clear_vars.mk
-
-ifeq ($(GAPPS_FORCE_MATCHING_DPI),)
-  GAPPS_FORCE_MATCHING_DPI := false
-endif
+GAPPS_SOURCES_PATH ?= vendor/opengapps/sources
+GAPPS_FORCE_MATCHING_DPI ?= false
 
 ifeq ($(GAPPS_FORCE_MATCHING_DPI),false)
   GAPPS_AAPT_PATH := $(shell find prebuilts/sdk/tools/$(HOST_OS) -executable -name aapt | head -n 1)
@@ -24,14 +20,15 @@ endif
 
 include $(GAPPS_BUILD_SYSTEM_PATH)/definitions.mk
 
-# Device should define their GAPPS_VARIANT in device/manufacturer/product/BoardConfig.mk
+# Device should define their GAPPS_VARIANT in device/manufacturer/product/device.mk
 ifeq ($(GAPPS_VARIANT),)
   $(error GAPPS_VARIANT must be configured)
 endif
-GAPPS_VARIANT_EVAL := $(call get-gapps-variant,$(GAPPS_VARIANT))
+TARGET_GAPPS_VARIANT := $(call get-gapps-variant,$(GAPPS_VARIANT))
 
-ifeq ($(GAPPS_VARIANT_EVAL),)
+ifeq ($(TARGET_GAPPS_VARIANT),)
   $(error GAPPS_VARIANT $(GAPPS_VARIANT) was not found. Use of one of pico,nano,micro,mini,full,stock,super)
 endif
 
-TARGET_GAPPS_VARIANT := $(GAPPS_VARIANT_EVAL)
+include $(GAPPS_DEVICE_FILES_PATH)/opengapps-packages.mk
+include $(GAPPS_DEVICE_FILES_PATH)/opengapps-files.mk


### PR DESCRIPTION
OpenGApps source can be specified using GAPPS_SOURCES_PATH (default value: vendor/opengapps/sources)

Both opengapps-packages.mk and the aosp build system were including config.mk.
Including it from the build system is not necessary.
By not relying on the aosp build system to include it, we can move the repository and add the google apps only on specific devices/configurations.

Note: after this, device.mk should include opengapps.mk instead of opengapps-packages.mk

Since the "config.mk" trick is not used anymore, this should also solve #37 (been using this for a while now without any issue)