### PR TITLE
Revert "Remove PrebuiltExchange3Google"

### DIFF
--- a/modules/PrebuiltExchange3Google/Android.mk
+++ b/modules/PrebuiltExchange3Google/Android.mk
@@ -1,0 +1,10 @@
+LOCAL_PATH := .
+include $(CLEAR_VARS)
+include $(GAPPS_CLEAR_VARS)
+LOCAL_MODULE := PrebuiltExchange3Google
+LOCAL_PACKAGE_NAME := com.google.android.gm.exchange
+LOCAL_PRIVILEGED_MODULE := true
+
+LOCAL_OVERRIDES_PACKAGES := Exchange2
+
+include $(BUILD_GAPPS_PREBUILT_APK)

--- a/opengapps-packages.mk
+++ b/opengapps-packages.mk
@@ -26,6 +26,7 @@ PRODUCT_PACKAGES += FaceLock \
 
 ifneq ($(filter $(TARGET_GAPPS_VARIANT),micro),) # require at least micro
 PRODUCT_PACKAGES += CalendarGooglePrebuilt \
+                    PrebuiltExchange3Google \
                     PrebuiltGmail \
                     GoogleHome
                     


### PR DESCRIPTION
This reverts commit b90e42365fc7a39b3e8026bb8355a5e6ebe9a2f1.

@mfonville:
I had made a mistake, and instead of completely removing ExchangeGoogle it has moved from /app to /priv-app
So we need to revert that last commit, and update the install path.

Refs #43