### PR TITLE
build: Do not force to use stock if user wants WebViewGoogle

### DIFF
--- a/modules/WebViewGoogle/Android.mk
+++ b/modules/WebViewGoogle/Android.mk
@@ -6,6 +6,8 @@ LOCAL_PACKAGE_NAME := com.google.android.webview
 
 LOCAL_OVERRIDES_PACKAGES := webview
 
+DEVICE_PACKAGE_OVERLAYS += $(GAPPS_DEVICE_FILES_PATH)/overlay/stock
+
 LOCAL_REQUIRED_MODULES := libwebviewchromium_loader \
                           libwebviewchromium_plat_support
 

--- a/opengapps-packages.mk
+++ b/opengapps-packages.mk
@@ -63,8 +63,6 @@ PRODUCT_PACKAGES += Books \
 
 ifneq ($(filter $(TARGET_GAPPS_VARIANT),stock),) # require at least stock
 
-DEVICE_PACKAGE_OVERLAYS += $(GAPPS_DEVICE_FILES_PATH)/overlay/stock
-
 PRODUCT_PACKAGES += GoogleCamera \
                     GoogleContacts \
                     LatinImeGoogle \


### PR DESCRIPTION
in the case if the user is using another gapps module different than stock and wants use WebViewGoogle this will be affected
by missing overlay for it .... move it to proper .mk for make it call every time when WebViewGoogle is set in any gapps module

Signed-off-by: David Viteri <davidteri91@gmail.com>