### PR TITLE
build: GoogleHome: override Home

### DIFF
--- a/modules/GoogleHome/Android.mk
+++ b/modules/GoogleHome/Android.mk
@@ -5,6 +5,6 @@ LOCAL_MODULE := GoogleHome
 LOCAL_PACKAGE_NAME := com.google.android.launcher
 
 GAPPS_LOCAL_OVERRIDES_MIN_VARIANT := stock
-GAPPS_LOCAL_OVERRIDES_PACKAGES := Launcher2 Launcher3
+GAPPS_LOCAL_OVERRIDES_PACKAGES := Home Launcher2 Launcher3
 
 include $(BUILD_GAPPS_PREBUILT_APK)


### PR DESCRIPTION
in the case Launcher2 and Launcher3 are removed from manifest .... android build is going to build Home as stock launcher
https://android.googlesource.com/platform/development/+/android-6.0.1_r43/samples/Home/Android.mk

Signed-off-by: David Viteri <davidteri91@gmail.com>