### PR TITLE
GoogleEarth does not match any module name

### DIFF
--- a/opengapps-packages.mk
+++ b/opengapps-packages.mk
@@ -81,7 +81,6 @@ endif
 
 PRODUCT_PACKAGES += Wallet \
                     DMAgent \
-                    GoogleEarth \
                     GCS \
                     GoogleHindiIME \
                     GoogleJapaneseInput \


### PR DESCRIPTION
GoogleEarth was listed as product package for the super gapps variant but it does not match any local module name.
Earth was correctly added in commit 766547955aa42b4bd001ca4795c1726b54090d02