### PR TITLE
Chrome: also override Browser2

### DIFF
--- a/modules/Chrome/Android.mk
+++ b/modules/Chrome/Android.mk
@@ -5,6 +5,6 @@ LOCAL_MODULE := Chrome
 LOCAL_PACKAGE_NAME := com.android.chrome
 
 GAPPS_LOCAL_OVERRIDES_MIN_VARIANT := stock
-GAPPS_LOCAL_OVERRIDES_PACKAGES := Browser BrowserProviderProxy Chromium Fluxion Gello
+GAPPS_LOCAL_OVERRIDES_PACKAGES := Browser Browser2 BrowserProviderProxy Chromium Fluxion Gello
 
 include $(BUILD_GAPPS_PREBUILT_APK)


### PR DESCRIPTION
https://android.googlesource.com/platform/packages/apps/Browser2/

This is used on AOSP Master branches

Signed-off-by: Adam Farden <adam@farden.cz>