### PR TITLE
Allow override AOSP Dialer

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ If you want to include WebViewGoogle on a non-stock build you need:
 GAPPS_FORCE_WEBVIEW_OVERRIDES := true
 ```
 
+If you want to include Google Dialer on a non-stock build you need:
+
+```
+GAPPS_FORCE_DIALER_OVERRIDES := true
+```
+
 On a per-app basis, add the GApps package to `GAPPS_PACKAGE_OVERRIDES`.
 Example:
 

--- a/opengapps-packages.mk
+++ b/opengapps-packages.mk
@@ -68,6 +68,9 @@ PRODUCT_PACKAGES += Books \
 ifneq ($(filter $(TARGET_GAPPS_VARIANT),stock),) # require at least stock
 
 GAPPS_FORCE_WEBVIEW_OVERRIDES := true
+ifneq ($(filter $(call get-allowed-api-levels),23),)
+GAPPS_FORCE_DIALER_OVERRIDES := true
+endif
 
 PRODUCT_PACKAGES += GoogleCamera \
                     GoogleContacts \
@@ -104,4 +107,11 @@ endif # end nano
 ifeq ($(GAPPS_FORCE_WEBVIEW_OVERRIDES),true)
 DEVICE_PACKAGE_OVERLAYS += $(GAPPS_DEVICE_FILES_PATH)/overlay/webview
 PRODUCT_PACKAGES += WebViewGoogle
+endif
+
+ifneq ($(filter $(call get-allowed-api-levels),23),)
+ifeq ($(GAPPS_FORCE_DIALER_OVERRIDES),true)
+DEVICE_PACKAGE_OVERLAYS += $(GAPPS_DEVICE_FILES_PATH)/overlay/dialer
+PRODUCT_PACKAGES += GoogleDialer
+endif
 endif

--- a/overlay/dialer/packages/services/Telecomm/res/values/config.xml
+++ b/overlay/dialer/packages/services/Telecomm/res/values/config.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2014 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<resources>
+    <!-- Package name for the default in-call UI and dialer [DO NOT TRANSLATE] -->
+    <string name="ui_default_package" translatable="false">com.google.android.dialer</string>
+
+    <!-- Class name for the default main dialer activity [DO NOT TRANSLATE] -->
+    <string name="dialer_default_class" translatable="false">com.google.android.dialer.extensions.GoogleDialtactsActivity</string>
+</resources>

--- a/overlay/dialer/packages/services/Telephony/res/values/config.xml
+++ b/overlay/dialer/packages/services/Telephony/res/values/config.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2014 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<resources>
+    <!-- Package name for the default in-call UI and dialer [DO NOT TRANSLATE] -->
+    <string name="ui_default_package" translatable="false">com.google.android.dialer</string>
+
+    <!-- Class name for the default main dialer activity [DO NOT TRANSLATE] -->
+    <string name="dialer_default_class" translatable="false">com.google.android.dialer.extensions.GoogleDialtactsActivity</string>
+</resources>


### PR DESCRIPTION
Using this system you will use GoogleDialer as stock and override AOSP Dialer .... the patches practically
let you to use InCallUI without have AOSP Dialer or it is impossilble .....

Signed-off-by: David Viteri <davidteri91@gmail.com>