### PR TITLE
find_apk: Fix compatibility with Bash 3.2

### DIFF
--- a/core/find_apk.sh
+++ b/core/find_apk.sh
@@ -10,7 +10,6 @@ getlatestapk() {
   sourceapk=""
   highcompatversion=""
   tempapks=( )
-  declare -n currapk="tempapks$i"
   OLDIFS="$IFS"
   IFS="
 " # We set IFS to newline here so that spaces can survive the for loop
@@ -51,7 +50,7 @@ getlatestapk() {
         break;
       fi
       # Add package to list.
-      currapk+=("$foundapk")
+      tempapks+=("$foundapk")
     fi
   done
   


### PR DESCRIPTION
Lollipop is, by recommendation, built on Ubuntu 12.04 where Bash 3.2
is the latest.

declare -n was added in Bash 3.3.

CC: @Dudulle - since you made the change I would love if you could take a look. I tested it on Lollipop and it works fine. I don't see how `currapk` was actually needed.