### PR TITLE
Always use the highest compatible API level.

### DIFF
--- a/core/find_apk.sh
+++ b/core/find_apk.sh
@@ -2,56 +2,47 @@
 
 getlatestapk() {
   # This functions finds the latest available version for the given architeture.
-  if ! stat --printf='' "$SOURCES/$2/"*"app/$1" 2> /dev/null; then
-    return 1 #appname is not there, error!?
-  fi
-  appname="$1"
-  aaptcmd="$4"
+  aaptcmd="$3"
   sourceapk=""
-  highcompatversion=""
+  highversion=""
   tempapks=( )
   OLDIFS="$IFS"
   IFS="
 " # We set IFS to newline here so that spaces can survive the for loop
   # sed copies filename to the beginning, to compare version, and later we remove it with cut
-  for foundapk in $(find $SOURCES/$2/*app/$1 -iname '*.apk' | sed 's!.*/\(.*\)!\1/&!' | sort -r -t/ -k1,1 | cut -d/ -f2-); do
-    foundpath="$(dirname "$(dirname "$foundapk")")"
-    api="$(basename "$foundpath")"
+  for foundapk in $(find "$1" -iname '*.apk' | sed 's!.*/\(.*\)!\1/&!' | sort -r -t/ -k1,1 | cut -d/ -f2-); do
+    # Get package version name
+    apkprops="$("$aaptcmd" dump badging "$foundapk" 2> /dev/null)"
+    apkversion="$(echo "$apkprops" | awk -F="'" '/versionName=/ {print $4}' | sed "s/'.*//g")"
+    # Get invariant version name.
+    # We first remove evrything after the first space.
+    apkversion="$(printf "$apkversion" | cut -d ' ' -f 1)"
+    # Then, we remove everything after the fourth dot.
+    apkversionparts=$(echo "$apkversion" | tr '.' '\n')
+    j=0
+    apkversion=""
     
-    if [ "$api" -le "$API" ]; then
-      # Get package version name
-      apkprops="$("$aaptcmd" dump badging "$foundapk" 2> /dev/null)"
-      apkversion="$(echo "$apkprops" | awk -F="'" '/versionName=/ {print $4}' | sed "s/'.*//g")"
-      # Get invariant version name.
-      # We first remove evrything after the first space.
-      apkversion="$(printf "$apkversion" | cut -d ' ' -f 1)"
-      # Then, we remove everything after the fourth dot.
-      apkversionparts=$(echo "$apkversion" | tr '.' '\n')
-      j=0
-      apkversion=""
-      
-      for part in ${apkversionparts[@]}; do
-        if [ $j -ge 4 ]; then
+    for part in ${apkversionparts[@]}; do
+      if [ $j -ge 4 ]; then
         break;
-        else
-          if [ $j -ge 1 ]; then
-            apkversion+="."
-          fi
-          apkversion+="$part"
-          ((j++))      
+      else
+        if [ $j -ge 1 ]; then
+          apkversion+="."
         fi
-      done
-      
-      if [ -z "$highcompatversion" ]; then
-        # Take note of the highest compatible version.
-        highcompatversion="$apkversion"
-      elif [ "$highcompatversion" != "$apkversion" ]; then
-        # Skip lower versions.
-        break;
+        apkversion+="$part"
+        ((j++))
       fi
-      # Add package to list.
-      tempapks+=("$foundapk")
+    done
+    
+    if [ -z "$highversion" ]; then
+      # Take note of the highest version.
+      highversion="$apkversion"
+    elif [ "$highversion" != "$apkversion" ]; then
+      # Skip lower versions.
+      break;
     fi
+    # Add package to list.
+    tempapks+=("$foundapk")
   done
   
   if [ ${#tempapks[@]} -ge 2 ]; then
@@ -59,15 +50,15 @@ getlatestapk() {
     for foundapk in ${tempapks[@]}; do
       dpipath="$(dirname "$foundapk")"
       dpi="$(basename "$dpipath")"
-      if [[ "$dpi" = "nodpi" || "$dpi" = "$3" ]]; then
+      if [[ "$dpi" = "nodpi" || "$dpi" = "$2" ]]; then
         sourceapk="$foundapk"
         break;
       fi
       
-      if [ "$3" != "nodpi" ]; then
+      if [ "$2" != "nodpi" ]; then
         # Check if the package dpi is a range and if the device falls between that range
         lodpi=$(echo "$dpi" | cut -d '-' -f 1)
-        if [[ "$lodpi" != "$dpi" && "$lodpi" -le "$3" && $(echo "$dpi" | rev | cut -d '-' -f 1 | rev) -ge "$3" ]]; then
+        if [[ "$lodpi" != "$dpi" && "$lodpi" -le "$2" && $(echo "$dpi" | rev | cut -d '-' -f 1 | rev) -ge "$2" ]]; then
           sourceapk="$foundapk"
           break;
         fi
@@ -75,7 +66,7 @@ getlatestapk() {
     done
     
     # If the device is set to nodpi, we take the highest dpi available. This should be the first one on the list.
-    if [[ -z "$sourceapk" && "$3" = "nodpi" ]]; then
+    if [[ -z "$sourceapk" && "$2" = "nodpi" ]]; then
       sourceapk="$tempapks"
     fi
     
@@ -87,7 +78,7 @@ getlatestapk() {
         # If this is a range, we already know the device is either over or under that range.
         # Therefore, we can safely take any value.
         dpi=$(echo "$dpi" | cut -d '-' -f 1)
-        if [ "$dpi" -ge "$3" ]; then
+        if [ "$dpi" -ge "$2" ]; then
           sourceapk="$foundapk"
         else
           # If we havn't found a higher dpi, we take the first (highest) lower dpi.
@@ -105,66 +96,72 @@ getlatestapk() {
   
   IFS="$OLDIFS"
   if [ -z "$sourceapk" ]; then
-    echo "WARNING: No APK found compatible with API level $API for package $appname on $2" >&2
+    echo "WARNING: No APK found compatible with API level $API for package $PACKAGE_NAME on $ARCH" >&2
     return 1 #error
   fi
   
-  api="$(basename "$(dirname "$(dirname "$sourceapk")")")"
-  
-  #$sourceapk and $api have the useful returnvalues
+  #$sourceapk has the useful return value
   return 0 #return that it was a success
 }
 
 getconformapk() {
   # This functions finds the latest available version for the given architeture and dpi. IF the chosen dpi is not available, nodpi will be selected.
-  if ! stat --printf='' "$SOURCES/$2/"*"app/$1" 2> /dev/null; then
-    return 1 #appname is not there, error!?
-  fi
-  appname="$1"
   sourceapk=""
   OLDIFS="$IFS"
   IFS="
 " # We set IFS to newline here so that spaces can survive the for loop
   # sed copies filename to the beginning, to compare version, and later we remove it with cut
-  for foundapk in $(find $SOURCES/$2/*app/$1 -iname '*.apk' | sed 's!.*/\(.*\)!\1/&!' | sort -r -t/ -k1,1 | cut -d/ -f2-); do
+  for foundapk in $(find "$1" -iname '*.apk' | sed 's!.*/\(.*\)!\1/&!' | sort -r -t/ -k1,1 | cut -d/ -f2-); do
     founddpipath="$(dirname "$foundapk")"
     dpi="$(basename "$founddpipath")"
     lodpi=$(echo "$dpi" | cut -d '-' -f 1)
-    if [[ "$dpi" = "nodpi" || "$dpi" = "$3"
-       || ( "$3" != "nodpi" && "$lodpi" != "$dpi" && "$lodpi" -le "$3" && $(echo "$dpi" | rev | cut -d '-' -f 1 | rev) -ge "$3" ) ]]; then
-      foundpath="$(dirname "$founddpipath")"
-      api="$(basename "$foundpath")"
-      if [ "$api" -le "$API" ]; then
+    if [[ "$dpi" = "nodpi" || "$dpi" = "$2"
+       || ( "$2" != "nodpi" && "$lodpi" != "$dpi" && "$lodpi" -le "$2" && $(echo "$dpi" | rev | cut -d '-' -f 1 | rev) -ge "$2" ) ]]; then
         sourceapk="$foundapk"
-        break;
-      fi
     fi
   done
   
   IFS="$OLDIFS"
   if [ -z "$sourceapk" ]; then
-    echo "WARNING: No APK found compatible with API level $API for package $appname on $2 and dpi $3" >&2
+    echo "WARNING: No APK found compatible with API level $API for package $PACKAGE_NAME on $ARCH and dpi $2" >&2
     return 1 #error
   fi
-  #$sourceapk and $api have the useful returnvalues
+  #$sourceapk has the useful return value
   return 0 #return that it was a success
 }
 
 getapk()
 {
-  if [ "$4" = false ]; then
-    aaptcmd="$5"
+  if [ "$3" = false ]; then
+    aaptcmd="$4"
     if hash "$aaptcmd" 2> /dev/null; then
-      getlatestapk "$1" "$2" "$3" "$aaptcmd"
+      getlatestapk "$1" "$2" "$aaptcmd"
     else
       echo "ERROR: aapt not found. Unable to detect latest package." >&2
       return 1
     fi
   else
-    getconformapk "$1" "$2" "$3"
+    getconformapk "$1" "$2"
   fi
   
   return $?
+}
+
+getappapidir() {
+  # Check if app directory exists.
+  if [ ! -d "$1/$2/"*"app/$3" ]; then
+    return 1 # Package does not exist for this arch.
+  fi
+  
+  for apidir in $(ls -vr "$1/$2/"*"app/$3"); do
+    if [ "$apidir" -le "$4" ]; then
+      appapidir=$(echo "$1/$2/"*"app/$3/$apidir")
+      return 0
+    fi
+  done
+  
+  echo "WARNING: No APK found compatible with API level $4 for package $3 on $2" >&2
+  return 1
 }
 
 getdpivalue() {
@@ -203,13 +200,17 @@ ARCH="$5"
 FORCE_DPI="$6"
 AAPT_CMD="$7"
 
+if ! getappapidir "$SOURCES" "$ARCH" "$PACKAGE_NAME" "$API"; then
+  exit 1
+fi
+
 if getdpivalue "$DPI"; then
-  if getapk "$PACKAGE_NAME" "$ARCH" "$dpivalue" "$FORCE_DPI" "$AAPT_CMD"; then
+  if getapk "$appapidir" "$dpivalue" "$FORCE_DPI" "$AAPT_CMD"; then
     echo "$sourceapk"
   else
     exit 1
   fi
-elif getapk "$PACKAGE_NAME" "$ARCH" "nodpi" "$FORCE_DPI" "$AAPT_CMD"; then
+elif getapk "$appapidir" "nodpi" "$FORCE_DPI" "$AAPT_CMD"; then
   echo "$sourceapk"
 else
   exit 1


### PR DESCRIPTION
Some apps (at least Play Services) will not work if they have multiple api levels and the one installed is not the highest API the device can take.
This cannot be detected from aapt because the min and target sdk in the manifest are the same.
It is therefore better to favor the correct API level instead a more recent package which might not work.