### PR TITLE
Fix typos in calls to get-allowed-api-levels

### DIFF
--- a/modules/FaceLock/Android.mk
+++ b/modules/FaceLock/Android.mk
@@ -1,5 +1,5 @@
 # libfacelock_jni.so was renamed to libfacenet.so in Nougat+
-ifeq ($(filter $(call-get-allowed-api-levels),24),)
+ifeq ($(filter $(call get-allowed-api-levels),24),)
 FACELOCK_JNI_NAME := libfacelock_jni
 else
 FACELOCK_JNI_NAME := libfacenet

--- a/opengapps-files.mk
+++ b/opengapps-files.mk
@@ -4,7 +4,7 @@ PRODUCT_COPY_FILES += $(call gapps-copy-to-system,all,etc framework)
 # Pico and higher
 ifneq ($(filter $(TARGET_GAPPS_VARIANT),pico),)
 # vendor/pittpatt seems to be removed on N+ (so only copy it to older than N)
-ifeq ($(filter $(call-get-allowed-api-levels),24),)
+ifeq ($(filter $(call get-allowed-api-levels),24),)
   PRODUCT_COPY_FILES += $(call gapps-copy-to-system,all,vendor/pittpatt)
 endif
   PRODUCT_COPY_FILES += $(call gapps-copy-to-system,all,usr/srec)


### PR DESCRIPTION
Drop the hyphens.  Because of these typos, files were incorrectly
installed under /system/vendor/pittpatt and this can cause build
failures in devices that use a separate vendor partition:

  Non-symlink out/target/product/bullhead/system/vendor detected!
  You cannot install files to out/target/product/bullhead/system/vendor while building a separate vendor.img!
  ninja: build stopped: subcommand failed.