### PR TITLE
Handle lz compressed apks

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -22,6 +22,14 @@ ifeq ($(GAPPS_FORCE_MATCHING_DPI),false)
   endif
 endif
 
+GAPPS_LUNZIP_REQUIRED := $(shell find $(GAPPS_SOURCES_PATH) -name '*.apk.lz' -print -quit)
+ifneq ($(GAPPS_LUNZIP_REQUIRED),)
+  GAPPS_TEST_LUNZIP := $(shell command -v lunzip)
+  ifeq ($(GAPPS_TEST_LUNZIP),)
+    $(error lunzip is not available. Please install it first ("sudo apt-get install lunzip"))
+  endif
+endif
+
 include $(GAPPS_BUILD_SYSTEM_PATH)/definitions.mk
 
 # Device should define their GAPPS_VARIANT in device/manufacturer/product/BoardConfig.mk

--- a/core/find_apk.sh
+++ b/core/find_apk.sh
@@ -8,7 +8,15 @@ getlatestapk() {
   tempapks=( )
   OLDIFS="$IFS"
   IFS="
-" # We set IFS to newline here so that spaces can survive the for loop
+" # We set IFS to newline here so that filenames containing spaces are
+  # handled correctly in the for-loops below.
+
+  # decompress apks
+  # some apks are lz compressed to work around github file-size limits.
+  for foundapklz in $(find "$1" -iname '*.apk.lz'); do
+    lunzip --keep "$foundapklz"
+  done
+
   # sed copies filename to the beginning, to compare version, and later we remove it with cut
   for foundapk in $(find "$1" -iname '*.apk' | sed 's!.*/\(.*\)!\1/&!' | sort -r -t/ -k1,1 | cut -d/ -f2-); do
     # Get package version name


### PR DESCRIPTION
Some apks are lz compressed to workaround github file-size limits.
Use "lunzip" to decompress them.