### PR TITLE
Implement GAPPS_EXCLUDED_PACKAGES

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ $(call inherit-product, vendor/google/build/opengapps-packages.mk)
 
 ## Customizations
 ### Adding extra packages
-You can add packages from versions higher then your set version. E.g. if you want to include `Chrome`, but you use `GAPPS_VARIANT:=micro`
+You can add packages from versions higher then your set version. E.g. if you want to include `Chrome`, but you use `GAPPS_VARIANT := micro`
 
 In your `device/manufacturer/product/device.mk` just add, for example:
 
@@ -59,6 +59,14 @@ PRODUCT_PACKAGES += Chrome
 ```
 
 This uses the module name. You can find the module name for a package by checking `vendor/google/build/modules/` and look at the `LOCAL_MODULE` value.
+
+### Excluding packages
+You can exclude certain packages from the list of packages associated with your selected OpenGapps variant. E.g. if you have `GAPPS_VARIANT := stock`
+and want all those apps installed except for `Hangouts`, then in your `device/manufacturer/product/device.mk` just add:
+
+```
+GAPPS_EXCLUDED_PACKAGES := Hangouts
+```
 
 ### Force stock package overrides
 You can force GApps packages to override the stock packages.

--- a/opengapps-packages.mk
+++ b/opengapps-packages.mk
@@ -3,7 +3,7 @@ include $(GAPPS_FILES)
 
 DEVICE_PACKAGE_OVERLAYS += $(GAPPS_DEVICE_FILES_PATH)/overlay/pico
 
-PRODUCT_PACKAGES += GoogleBackupTransport \
+GAPPS_PRODUCT_PACKAGES += GoogleBackupTransport \
                     GoogleContactsSyncAdapter \
                     GoogleFeedback \
                     GoogleOneTimeInitializer \
@@ -16,27 +16,27 @@ PRODUCT_PACKAGES += GoogleBackupTransport \
                     GoogleCalendarSyncAdapter
 
 ifneq ($(filter $(call get-allowed-api-levels),23),)
-PRODUCT_PACKAGES += GoogleTTS \
+GAPPS_PRODUCT_PACKAGES += GoogleTTS \
                     GooglePackageInstaller
 endif
 
 ifneq ($(filter $(TARGET_GAPPS_VARIANT),nano),) # require at least nano
-PRODUCT_PACKAGES += FaceLock \
+GAPPS_PRODUCT_PACKAGES += FaceLock \
                     HotwordEnrollment \
                     Velvet
 
 ifneq ($(filter $(TARGET_GAPPS_VARIANT),micro),) # require at least micro
-PRODUCT_PACKAGES += CalendarGooglePrebuilt \
+GAPPS_PRODUCT_PACKAGES += CalendarGooglePrebuilt \
                     PrebuiltExchange3Google \
                     PrebuiltGmail \
                     GoogleHome
 
 ifeq ($(filter $(call get-allowed-api-levels),23),)
-PRODUCT_PACKAGES += GoogleTTS
+GAPPS_PRODUCT_PACKAGES += GoogleTTS
 endif
 
 ifneq ($(filter $(TARGET_GAPPS_VARIANT),mini),) # require at least mini
-PRODUCT_PACKAGES += CalculatorGoogle \
+GAPPS_PRODUCT_PACKAGES += CalculatorGoogle \
                     PrebuiltDeskClockGoogle \
                     PlusOne \
                     Hangouts \
@@ -47,7 +47,7 @@ PRODUCT_PACKAGES += CalculatorGoogle \
 ifneq ($(filter $(TARGET_GAPPS_VARIANT),full),) # require at least full
 
 GAPPS_FORCE_BROWSER_OVERRIDES := true
-PRODUCT_PACKAGES += Books \
+GAPPS_PRODUCT_PACKAGES += Books \
                     CloudPrint2 \
                     EditorsDocs \
                     Drive \
@@ -69,14 +69,14 @@ ifneq ($(filter $(call get-allowed-api-levels),23),)
 GAPPS_FORCE_DIALER_OVERRIDES := true
 endif
 GAPPS_FORCE_MMS_OVERRIDES := true
-PRODUCT_PACKAGES += GoogleCamera \
+GAPPS_PRODUCT_PACKAGES += GoogleCamera \
                     GoogleContacts \
                     LatinImeGoogle \
                     TagGoogle \
                     GoogleVrCore
 
 ifneq ($(filter $(call get-allowed-api-levels),24),)
-PRODUCT_PACKAGES += GooglePrintRecommendationService \
+GAPPS_PRODUCT_PACKAGES += GooglePrintRecommendationService \
                     GoogleExtServices \
                     GoogleExtShared
 endif
@@ -84,9 +84,9 @@ endif
 ifneq ($(filter $(TARGET_GAPPS_VARIANT),super),)
 
 ifneq ($(filter $(call get-allowed-api-levels),23),)
-PRODUCT_PACKAGES += AndroidForWork
+GAPPS_PRODUCT_PACKAGES += AndroidForWork
 endif
-PRODUCT_PACKAGES += Wallet \
+GAPPS_PRODUCT_PACKAGES += Wallet \
                     DMAgent \
                     GoogleEarth \
                     GCS \
@@ -105,6 +105,8 @@ endif # end full
 endif # end mini
 endif # end micro
 endif # end nano
+
+PRODUCT_PACKAGES += $(filter-out $(GAPPS_EXCLUDED_PACKAGES),$(GAPPS_PRODUCT_PACKAGES))
 
 ifeq ($(GAPPS_FORCE_WEBVIEW_OVERRIDES),true)
 ifneq ($(filter-out $(call get-allowed-api-levels),24),)


### PR DESCRIPTION
Allow certain apps to be excluded from the list of apps installed
by an OpenGapps variant.  E.g. if you set

  GAPPS_VARIANT := stock
  GAPPS_EXCLUDED_PACKAGES := \
     Hangouts \
     EditorsSlides

then all the apps in the "stock" package will be installed except for
Hangouts and EditorSlides.