### PR TITLE
build: Fix for Pixel Launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,10 +102,10 @@ If you want to include Chrome on a non-full build you need:
 GAPPS_FORCE_BROWSER_OVERRIDES := true
 ```
 
-If you want use PixelHome overriding GoogleHome you need:
+If you want use PixelLauncher overriding GoogleHome you need:
 
 ```
-GAPPS_FORCE_PIXEL_HOME := true
+GAPPS_FORCE_PIXEL_LAUNCHER := true
 ```
 
 On a per-app basis, add the GApps package to `GAPPS_PACKAGE_OVERRIDES`.

--- a/modules/PixelLauncher/Android.mk
+++ b/modules/PixelLauncher/Android.mk
@@ -1,8 +1,9 @@
 LOCAL_PATH := .
 include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
-LOCAL_MODULE := PixelHome
+LOCAL_MODULE := PixelLauncher
 LOCAL_PACKAGE_NAME := com.google.android.apps.nexuslauncher
+LOCAL_PRIVILEGED_MODULE := true
 
 GAPPS_LOCAL_OVERRIDES_PACKAGES := Home GoogleHome Launcher2 Launcher3 Fluctuation Trebuchet
 

--- a/modules/PixelLauncherIcons/Android.mk
+++ b/modules/PixelLauncherIcons/Android.mk
@@ -1,7 +1,8 @@
 LOCAL_PATH := .
 include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
-LOCAL_MODULE := PixelHomeIcons
+LOCAL_MODULE := PixelLauncherIcons
 LOCAL_PACKAGE_NAME := com.google.android.nexusicons
+LOCAL_DEX_PREOPT := false
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/Wallpapers/Android.mk
+++ b/modules/Wallpapers/Android.mk
@@ -1,7 +1,7 @@
 LOCAL_PATH := .
 include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
-LOCAL_MODULE := Wallpaper
+LOCAL_MODULE := Wallpapers
 LOCAL_PACKAGE_NAME := com.google.android.apps.wallpaper
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/opengapps-packages.mk
+++ b/opengapps-packages.mk
@@ -159,12 +159,16 @@ PRODUCT_PACKAGES += \
     PrebuiltBugle
 endif
 
-ifeq ($(GAPPS_FORCE_PIXEL_HOME),true)
+ifeq ($(GAPPS_FORCE_PIXEL_LAUNCHER),true)
 GAPPS_EXCLUDED_PACKAGES += \
     GoogleHome
 
+ifneq ($(filter $(call get-allowed-api-levels),25),)
 PRODUCT_PACKAGES += \
-    PixelHome \
-    PixelHomeIcons \
-    Wallpaper        
+    PixelLauncherIcons
+endif
+
+PRODUCT_PACKAGES += \
+    PixelLauncher \
+    Wallpapers
 endif


### PR DESCRIPTION
make PixelLauncher a PRIVILEGED APP as https://github.com/opengapps/all/tree/master/priv-app/com.google.android.apps.nexuslauncher/21/nodpi
make PixelLauncherIcons builable for SDK >= 25 (Android Nougat 7.1) in old SDK it causes errors in build
rename Wallpaper to Wallpapers
match Google Play names

Signed-off-by: David Viteri <davidteri91@gmail.com>