### PR TITLE
pixelicons: use rounded pixel icons when available

### DIFF
--- a/opengapps-packages.mk
+++ b/opengapps-packages.mk
@@ -164,6 +164,9 @@ GAPPS_EXCLUDED_PACKAGES += \
     GoogleHome
 
 ifneq ($(filter $(call get-allowed-api-levels),25),)
+DEVICE_PACKAGE_OVERLAYS += \
+    $(GAPPS_DEVICE_FILES_PATH)/overlay/pixelicons
+
 PRODUCT_PACKAGES += \
     PixelLauncherIcons
 endif

--- a/overlay/pixelicons/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/pixelicons/frameworks/base/core/res/res/values/config.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+** Copyright 2011, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<!-- These resources are around just to allow their values to be customized
+     for different hardware and product builds. -->
+<resources>
+    <!-- Flag indicating whether round icons should be parsed from the application manifest. -->
+    <bool name="config_useRoundIcon">true</bool>
+</resources>


### PR DESCRIPTION
allowed only from android 7.1 and newer

Signed-off-by: David Viteri <davidteri91@gmail.com>