### PR TITLE
package name of SetupWizard is corrected

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,10 +102,10 @@ If you want to include Chrome on a non-full build you need:
 GAPPS_FORCE_BROWSER_OVERRIDES := true
 ```
 
-If you want use PixelHome overriding GoogleHome you need:
+If you want use PixelLauncher overriding GoogleHome you need:
 
 ```
-GAPPS_FORCE_PIXEL_HOME := true
+GAPPS_FORCE_PIXEL_LAUNCHER := true
 ```
 
 On a per-app basis, add the GApps package to `GAPPS_PACKAGE_OVERRIDES`.

--- a/config.mk
+++ b/config.mk
@@ -28,6 +28,10 @@ ifneq ($(GAPPS_LUNZIP_REQUIRED),)
   ifeq ($(GAPPS_TEST_LUNZIP),)
     $(error lunzip is not available. Please install it first ("sudo apt-get install lunzip"))
   endif
+
+  ifneq ($(filter clean installclean, $(MAKECMDGOALS)),)
+    $(shell find $(GAPPS_SOURCES_PATH) -name "*apk.lz" | sed 's/\.apk\.lz$$/\.apk/' | xargs rm -f)
+  endif
 endif
 
 include $(GAPPS_BUILD_SYSTEM_PATH)/definitions.mk

--- a/modules/PixelLauncher/Android.mk
+++ b/modules/PixelLauncher/Android.mk
@@ -1,8 +1,9 @@
 LOCAL_PATH := .
 include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
-LOCAL_MODULE := PixelHome
+LOCAL_MODULE := PixelLauncher
 LOCAL_PACKAGE_NAME := com.google.android.apps.nexuslauncher
+LOCAL_PRIVILEGED_MODULE := true
 
 GAPPS_LOCAL_OVERRIDES_PACKAGES := Home GoogleHome Launcher2 Launcher3 Fluctuation Trebuchet
 

--- a/modules/PixelLauncherIcons/Android.mk
+++ b/modules/PixelLauncherIcons/Android.mk
@@ -1,7 +1,8 @@
 LOCAL_PATH := .
 include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
-LOCAL_MODULE := PixelHomeIcons
+LOCAL_MODULE := PixelLauncherIcons
 LOCAL_PACKAGE_NAME := com.google.android.nexusicons
+LOCAL_DEX_PREOPT := false
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/SetupWizard/Android.mk
+++ b/modules/SetupWizard/Android.mk
@@ -2,10 +2,16 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := SetupWizard
-ifneq ($(filter $(PRODUCT_CHARACTERISTICS),tablet),)
-	LOCAL_PACKAGE_NAME := com.google.android.setupwizard.tablet
+ifeq ($(filter $(call get-allowed-api-levels),21),)
+  # kitkat
+  LOCAL_PACKAGE_NAME := com.google.android.setupwizard
 else
-	LOCAL_PACKAGE_NAME := com.google.android.setupwizard.default
+  # LP and newer
+  ifneq ($(filter $(PRODUCT_CHARACTERISTICS),tablet),)
+    LOCAL_PACKAGE_NAME := com.google.android.setupwizard.tablet
+  else 
+    LOCAL_PACKAGE_NAME := com.google.android.setupwizard.default
+  endif
 endif
 
 LOCAL_PRIVILEGED_MODULE := true

--- a/modules/Wallpapers/Android.mk
+++ b/modules/Wallpapers/Android.mk
@@ -1,7 +1,7 @@
 LOCAL_PATH := .
 include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
-LOCAL_MODULE := Wallpaper
+LOCAL_MODULE := Wallpapers
 LOCAL_PACKAGE_NAME := com.google.android.apps.wallpaper
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/opengapps-packages.mk
+++ b/opengapps-packages.mk
@@ -159,12 +159,16 @@ PRODUCT_PACKAGES += \
     PrebuiltBugle
 endif
 
-ifeq ($(GAPPS_FORCE_PIXEL_HOME),true)
+ifeq ($(GAPPS_FORCE_PIXEL_LAUNCHER),true)
 GAPPS_EXCLUDED_PACKAGES += \
     GoogleHome
 
+ifneq ($(filter $(call get-allowed-api-levels),25),)
 PRODUCT_PACKAGES += \
-    PixelHome \
-    PixelHomeIcons \
-    Wallpaper        
+    PixelLauncherIcons
+endif
+
+PRODUCT_PACKAGES += \
+    PixelLauncher \
+    Wallpapers
 endif

--- a/opengapps-packages.mk
+++ b/opengapps-packages.mk
@@ -114,6 +114,12 @@ endif # end mini
 endif # end micro
 endif # end nano
 
+# This needs to be at the end of standard files, but before the GAPPS_FORCE_* options,
+# since those also affect DEVICE_PACKAGE_OVERLAYS. We don't want to exclude a package
+# that also has an overlay, since that will make us use the overlay but not have the
+# package. This can cause issues.
+PRODUCT_PACKAGES += $(filter-out $(GAPPS_EXCLUDED_PACKAGES),$(GAPPS_PRODUCT_PACKAGES))
+
 ifeq ($(GAPPS_FORCE_WEBVIEW_OVERRIDES),true)
 ifneq ($(filter-out $(call get-allowed-api-levels),24),)
 DEVICE_PACKAGE_OVERLAYS += \
@@ -122,7 +128,7 @@ else
 DEVICE_PACKAGE_OVERLAYS += \
     $(GAPPS_DEVICE_FILES_PATH)/overlay/webview/24
 endif
-GAPPS_PRODUCT_PACKAGES += \
+PRODUCT_PACKAGES += \
     WebViewGoogle
 endif
 
@@ -131,7 +137,7 @@ ifneq ($(filter $(call get-allowed-api-levels),23),)
 DEVICE_PACKAGE_OVERLAYS += \
     $(GAPPS_DEVICE_FILES_PATH)/overlay/browser
 endif
-GAPPS_PRODUCT_PACKAGES += \
+PRODUCT_PACKAGES += \
     Chrome
 endif
 
@@ -140,7 +146,7 @@ ifeq ($(GAPPS_FORCE_DIALER_OVERRIDES),true)
 DEVICE_PACKAGE_OVERLAYS += \
     $(GAPPS_DEVICE_FILES_PATH)/overlay/dialer
 
-GAPPS_PRODUCT_PACKAGES += \
+PRODUCT_PACKAGES += \
     GoogleDialer
 endif
 endif
@@ -149,7 +155,7 @@ ifeq ($(GAPPS_FORCE_MMS_OVERRIDES),true)
 DEVICE_PACKAGE_OVERLAYS += \
     $(GAPPS_DEVICE_FILES_PATH)/overlay/mms
 
-GAPPS_PRODUCT_PACKAGES += \
+PRODUCT_PACKAGES += \
     PrebuiltBugle
 endif
 
@@ -157,10 +163,8 @@ ifeq ($(GAPPS_FORCE_PIXEL_HOME),true)
 GAPPS_EXCLUDED_PACKAGES += \
     GoogleHome
 
-GAPPS_PRODUCT_PACKAGES += \
+PRODUCT_PACKAGES += \
     PixelHome \
     PixelHomeIcons \
     Wallpaper        
 endif
-
-PRODUCT_PACKAGES += $(filter-out $(GAPPS_EXCLUDED_PACKAGES),$(GAPPS_PRODUCT_PACKAGES))

--- a/opengapps-packages.mk
+++ b/opengapps-packages.mk
@@ -164,6 +164,9 @@ GAPPS_EXCLUDED_PACKAGES += \
     GoogleHome
 
 ifneq ($(filter $(call get-allowed-api-levels),25),)
+DEVICE_PACKAGE_OVERLAYS += \
+    $(GAPPS_DEVICE_FILES_PATH)/overlay/pixelicons
+
 PRODUCT_PACKAGES += \
     PixelLauncherIcons
 endif

--- a/overlay/pixelicons/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/pixelicons/frameworks/base/core/res/res/values/config.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+** Copyright 2011, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<!-- These resources are around just to allow their values to be customized
+     for different hardware and product builds. -->
+<resources>
+    <!-- Flag indicating whether round icons should be parsed from the application manifest. -->
+    <bool name="config_useRoundIcon">true</bool>
+</resources>


### PR DESCRIPTION
Due to incorrect package name of SetupWizard module, compile fails.
Package name changed from 'com.google.android.setupwizard.default' to 'com.google.android.setupwizard'