### PR TITLE
Update GMS backup service overlay

### DIFF
--- a/overlay/pico/frameworks/base/packages/SettingsProvider/res/values/config.xml
+++ b/overlay/pico/frameworks/base/packages/SettingsProvider/res/values/config.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="def_backup_transport">com.google.android.backup/.BackupTransportService</string>
+    <string name="def_backup_transport">com.google.android.gms/.backup.BackupTransportService</string>
 </resources>


### PR DESCRIPTION
The GMS backup service is now integrated
in the main GMS package and also changed
its name.

Change-Id: I545c910eb1378a6ee8a4f7d97ca00605d264e2df
Signed-off-by: Alex Naidis <alex.naidis@linux.com>