### PR TITLE
Only build gapps if a variant was specified

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -1,3 +1,5 @@
+ifneq ($(GAPPS_VARIANT),)
+
 # Opengapps AOSP build system
 GAPPS_BUILD_SYSTEM_PATH := vendor/google/build/core
 GAPPS_SOURCES_PATH := vendor/opengapps/sources
@@ -37,9 +39,6 @@ endif
 include $(GAPPS_BUILD_SYSTEM_PATH)/definitions.mk
 
 # Device should define their GAPPS_VARIANT in device/manufacturer/product/BoardConfig.mk
-ifeq ($(GAPPS_VARIANT),)
-  $(error GAPPS_VARIANT must be configured)
-endif
 GAPPS_VARIANT_EVAL := $(call get-gapps-variant,$(GAPPS_VARIANT))
 
 ifeq ($(GAPPS_VARIANT_EVAL),)
@@ -47,3 +46,5 @@ ifeq ($(GAPPS_VARIANT_EVAL),)
 endif
 
 TARGET_GAPPS_VARIANT := $(GAPPS_VARIANT_EVAL)
+
+endif

--- a/core/clear_vars.mk
+++ b/core/clear_vars.mk
@@ -1,3 +1,7 @@
+ifneq ($(GAPPS_VARIANT),)
+
 # Reset custom local variables.
 GAPPS_LOCAL_OVERRIDES_PACKAGES :=
 GAPPS_LOCAL_OVERRIDES_MIN_VARIANT :=
+
+endif

--- a/core/definitions.mk
+++ b/core/definitions.mk
@@ -1,3 +1,5 @@
+ifneq ($(GAPPS_VARIANT),)
+
 define get-allowed-api-levels
 $(shell seq 1 "$(PLATFORM_SDK_VERSION)")
 endef
@@ -50,3 +52,5 @@ endef
 
 BUILD_GAPPS_PREBUILT_APK := $(GAPPS_BUILD_SYSTEM_PATH)/prebuilt_apk.mk
 BUILD_GAPPS_PREBUILT_SHARED_LIBRARY := $(GAPPS_BUILD_SYSTEM_PATH)/prebuilt_shared_library.mk
+
+endif

--- a/opengapps-packages.mk
+++ b/opengapps-packages.mk
@@ -1,6 +1,10 @@
 include vendor/google/build/config.mk
 include $(GAPPS_FILES)
 
+ifeq ($(GAPPS_VARIANT),)
+  $(error GAPPS_VARIANT must be configured)
+endif
+
 DEVICE_PACKAGE_OVERLAYS += \
     $(GAPPS_DEVICE_FILES_PATH)/overlay/pico
 


### PR DESCRIPTION
* This can be useful if building for several devices in the same tree, but
  only wanting to supply built-in gapps for specific ones.

* Throw up an info message that gapps are being skipped if GAPPS_VARIANT
  was not specified, but don't bail on the build completely because of it.