### PR TITLE
FaceLock Module : add condition to check if built target is arm arch

### DIFF
--- a/opengapps-packages.mk
+++ b/opengapps-packages.mk
@@ -28,8 +28,12 @@ GAPPS_PRODUCT_PACKAGES += \
 endif
 
 ifneq ($(filter $(TARGET_GAPPS_VARIANT),nano),) # require at least nano
+# support only arm based platforms
+ifneq ($(filter arm%, $(TARGET_ARCH)),)
 GAPPS_PRODUCT_PACKAGES += \
-    FaceLock \
+    FaceLock
+endif
+GAPPS_PRODUCT_PACKAGES += \
     Velvet
 
 ifneq ($(filter $(TARGET_GAPPS_VARIANT),micro),) # require at least micro


### PR DESCRIPTION
The FaceLock module only support arm based arch, a condition added for checking arch to avoid build error on x86/x86_64 target.