### PR TITLE
Fix HotwordEnrollment module name

### DIFF
--- a/modules/HotwordEnrollment/Android.mk
+++ b/modules/HotwordEnrollment/Android.mk
@@ -1,7 +1,7 @@
 LOCAL_PATH := .
 include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
-LOCAL_MODULE := Hotword
+LOCAL_MODULE := HotwordEnrollment
 LOCAL_PACKAGE_NAME := com.android.hotwordenrollment
 LOCAL_PRIVILEGED_MODULE := true
 


### PR DESCRIPTION
Module name should be "HotwordEnrollment", not "Hotword".

Note that "HotwordEnrollment" is referenced in `opengapps-packages.mk`.

This fixes issue #126.