### PR TITLE
make round icons opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ If you want use PixelLauncher overriding GoogleHome you need:
 GAPPS_FORCE_PIXEL_LAUNCHER := true
 ```
 
+If you want use Round Icons API you need:
+
+```makefile
+GAPPS_FORCE_ROUND_ICONS := true
+```
+
 On a per-app basis, add the GApps package to `GAPPS_PACKAGE_OVERRIDES`.
 Example:
 

--- a/opengapps-packages.mk
+++ b/opengapps-packages.mk
@@ -167,11 +167,13 @@ GAPPS_EXCLUDED_PACKAGES += \
     GoogleHome
 
 ifneq ($(filter $(call get-allowed-api-levels),25),)
+ifeq ($(GAPPS_FORCE_ROUND_ICONS),true)
 DEVICE_PACKAGE_OVERLAYS += \
     $(GAPPS_DEVICE_FILES_PATH)/overlay/pixelicons
 
 PRODUCT_PACKAGES += \
     PixelLauncherIcons
+endif
 endif
 
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
do this for android oreo launcher which can use adaptive icons

Signed-off-by: David Viteri <davidteri91@gmail.com>