### PR TITLE
Refactor "filter" statements

### DIFF
--- a/core/definitions.mk
+++ b/core/definitions.mk
@@ -19,7 +19,7 @@ $(shell "$(GAPPS_BUILD_SYSTEM_PATH)/find_apk.sh" "$(GAPPS_SOURCES_PATH)" "$(PLAT
 endef
 
 define get-lib-search-path
-$(if $(filter $(1),arm),lib/armeabi*/*,lib/$(1)*/*)
+$(if $(filter arm,$(1)),lib/armeabi*/*,lib/$(1)*/*)
 endef
 
 define find-libs-in-apk
@@ -28,13 +28,13 @@ endef
 
 define get-gapps-variant
 $(strip \
-$(if $(filter $(1),pico),pico) \
-$(if $(filter $(1),nano),pico nano) \
-$(if $(filter $(1),micro),pico nano micro) \
-$(if $(filter $(1),mini),pico nano micro mini) \
-$(if $(filter $(1),full),pico nano micro mini full) \
-$(if $(filter $(1),stock),pico nano micro mini full stock) \
-$(if $(filter $(1),super),pico nano micro mini full stock super) \
+$(if $(filter pico, $(1)),pico) \
+$(if $(filter nano, $(1)),pico nano) \
+$(if $(filter micro,$(1)),pico nano micro) \
+$(if $(filter mini, $(1)),pico nano micro mini) \
+$(if $(filter full, $(1)),pico nano micro mini full) \
+$(if $(filter stock,$(1)),pico nano micro mini full stock) \
+$(if $(filter super,$(1)),pico nano micro mini full stock super) \
 )
 endef
 

--- a/core/prebuilt_apk.mk
+++ b/core/prebuilt_apk.mk
@@ -8,14 +8,14 @@ CURRENT_PATH := $(GAPPS_DEVICE_FILES_PATH)/modules/$(LOCAL_MODULE)
 # Override packages from GAPPS_LOCAL_OVERRIDES_PACKAGES only when required.
 # If a package should NOT in any case be installed, add it directly to LOCAL_OVERRIDES_PACKAGES instead.
 ifneq ($(GAPPS_LOCAL_OVERRIDES_PACKAGES),)
-  ifeq ($(filter $(GAPPS_BYPASS_PACKAGE_OVERRIDES),$(LOCAL_MODULE)),)
+  ifeq ($(filter $(LOCAL_MODULE),$(GAPPS_BYPASS_PACKAGE_OVERRIDES)),)
     ifeq ($(GAPPS_FORCE_PACKAGE_OVERRIDES),true)
       LOCAL_OVERRIDES_PACKAGES += $(GAPPS_LOCAL_OVERRIDES_PACKAGES)
     else ifeq ($(GAPPS_LOCAL_OVERRIDES_MIN_VARIANT),)
       LOCAL_OVERRIDES_PACKAGES += $(GAPPS_LOCAL_OVERRIDES_PACKAGES)
-    else ifneq ($(filter $(TARGET_GAPPS_VARIANT),$(GAPPS_LOCAL_OVERRIDES_MIN_VARIANT)),)
+    else ifneq ($(filter $(GAPPS_LOCAL_OVERRIDES_MIN_VARIANT),$(TARGET_GAPPS_VARIANT)),)
       LOCAL_OVERRIDES_PACKAGES += $(GAPPS_LOCAL_OVERRIDES_PACKAGES)
-    else ifneq ($(filter $(GAPPS_PACKAGE_OVERRIDES),$(LOCAL_MODULE)),)
+    else ifneq ($(filter $(LOCAL_MODULE),$(GAPPS_PACKAGE_OVERRIDES)),)
       LOCAL_OVERRIDES_PACKAGES += $(GAPPS_LOCAL_OVERRIDES_PACKAGES)
     endif
   endif
@@ -28,7 +28,7 @@ ifdef LOCAL_SRC_FILES
 else
   LOCAL_SRC_FILES := $(call find-apk-for-pkg,$(TARGET_ARCH),$(LOCAL_PACKAGE_NAME))
   ifdef LOCAL_SRC_FILES
-    ifeq ($(filter $(call get-allowed-api-levels), 21),)
+    ifeq ($(filter 21,$(call get-allowed-api-levels)),)
       # only kitkat
       ifneq ($(call find-libs-in-apk,$(TARGET_ARCH),$(LOCAL_SRC_FILES)),)
         LOCAL_SHARED_LIBRARIES := $(notdir $(basename $(shell zipinfo -1 "$(LOCAL_SRC_FILES)" "$(call get-lib-search-path, $(TARGET_ARCH))" -x lib/*/crazy/* 2>/dev/null)))
@@ -50,7 +50,7 @@ include $(BUILD_PREBUILT)
 
 # generate mk file of shared library for kitkat
 ifdef LOCAL_SRC_FILES
-  ifeq ($(filter $(call get-allowed-api-levels), 21),)
+  ifeq ($(filter 21,$(call get-allowed-api-levels)),)
     ifneq ($(call find-libs-in-apk,$(TARGET_ARCH),$(LOCAL_SRC_FILES)),)
       $(shell unzip -qqq -j -o "$(LOCAL_SRC_FILES)" "$(call get-lib-search-path, $(TARGET_ARCH))" -x lib/*/crazy/* -d "$(GAPPS_SOURCES_PATH)"/$(TARGET_ARCH)/lib/19/lib_from_app 2>/dev/null)
       LIBRARIES :=

--- a/core/prebuilt_shared_library.mk
+++ b/core/prebuilt_shared_library.mk
@@ -31,7 +31,7 @@ ifdef TARGET_2ND_ARCH
   LOCAL_SRC_FILES_32 := $(call gapps-find-lib-for-arch,$(TARGET_2ND_ARCH),$(lib_prefix)lib,$(full_name))
 else
   LOCAL_SRC_FILES := $(call gapps-find-lib-for-arch,$(TARGET_ARCH),$(lib_prefix)lib,$(full_name))
-  ifeq ($(filter $(call get-allowed-api-levels), 21),)
+  ifeq ($(filter 21,$(call get-allowed-api-levels)),)
     # kitkat only
     ifeq ($(LOCAL_SRC_FILES),$(join $(GAPPS_SOURCES_PATH),/))
       # find libraries from lib/19/lib_from_app
@@ -46,7 +46,7 @@ is_vendor_lib :=
 lib_prefix :=
 full_name :=
 
-ifeq ($(filter $(call get-allowed-api-levels), 21),)
+ifeq ($(filter 21,$(call get-allowed-api-levels)),)
   # kitkat only
   mid := MODULE.$(if $(LOCAL_IS_HOST_MODULE),HOST,TARGET).$(LOCAL_MODULE_CLASS).$(LOCAL_MODULE)
   ifndef $(mid)

--- a/modules/FaceLock/Android.mk
+++ b/modules/FaceLock/Android.mk
@@ -1,6 +1,6 @@
 ifneq ($(filter arm%, $(TARGET_ARCH)),)
 # libfacelock_jni.so was renamed to libfacenet.so in Nougat+
-ifeq ($(filter $(call get-allowed-api-levels),24),)
+ifeq ($(filter 24,$(call get-allowed-api-levels)),)
 FACELOCK_JNI_NAME := libfacelock_jni
 else
 FACELOCK_JNI_NAME := libfacenet

--- a/modules/GooglePackageInstaller/Android.mk
+++ b/modules/GooglePackageInstaller/Android.mk
@@ -2,7 +2,7 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := GooglePackageInstaller
-ifneq ($(filter $(PRODUCT_CHARACTERISTICS),tv),)
+ifneq ($(filter tv,$(PRODUCT_CHARACTERISTICS)),)
         LOCAL_PACKAGE_NAME := com.google.android.pano.packageinstaller
 else
         LOCAL_PACKAGE_NAME := com.google.android.packageinstaller

--- a/modules/SetupWizard/Android.mk
+++ b/modules/SetupWizard/Android.mk
@@ -2,12 +2,12 @@ LOCAL_PATH := .
 include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := SetupWizard
-ifeq ($(filter $(call get-allowed-api-levels),21),)
+ifeq ($(filter 21,$(call get-allowed-api-levels)),)
   # kitkat
   LOCAL_PACKAGE_NAME := com.google.android.setupwizard
 else
   # LP and newer
-  ifneq ($(filter $(PRODUCT_CHARACTERISTICS),tablet),)
+  ifneq ($(filter tablet,$(PRODUCT_CHARACTERISTICS)),)
     LOCAL_PACKAGE_NAME := com.google.android.setupwizard.tablet
   else 
     LOCAL_PACKAGE_NAME := com.google.android.setupwizard.default

--- a/opengapps-files.mk
+++ b/opengapps-files.mk
@@ -9,9 +9,9 @@ BUILD_VENDORIMAGE := $(shell CALLED_FROM_SETUP=true BUILD_SYSTEM=build/core \
 endif
 
 # Pico and higher
-ifneq ($(filter $(TARGET_GAPPS_VARIANT),pico),)
+ifneq ($(filter pico,$(TARGET_GAPPS_VARIANT)),)
 # vendor/pittpatt seems to be removed on N+ (so only copy it to older than N)
-ifeq ($(filter $(call get-allowed-api-levels),24),)
+ifeq ($(filter 24,$(call get-allowed-api-levels)),)
   PITTPATT_COPY_FILES := $(call gapps-copy-to-system,all,vendor/pittpatt)
 # if we are building a vendor image, then we cannot copy to system/vendor, so update our copy statements.
 ifdef BUILD_VENDORIMAGE

--- a/opengapps-packages.mk
+++ b/opengapps-packages.mk
@@ -19,45 +19,45 @@ GAPPS_PRODUCT_PACKAGES += \
     Phonesky \
     GoogleCalendarSyncAdapter
 
-ifneq ($(filter $(call get-allowed-api-levels),23),)
+ifneq ($(filter 23,$(call get-allowed-api-levels)),)
 GAPPS_PRODUCT_PACKAGES += \
     GoogleTTS \
     GooglePackageInstaller
 endif
 
-ifneq ($(filter $(call get-allowed-api-levels),24),)
+ifneq ($(filter 24,$(call get-allowed-api-levels)),)
 GAPPS_PRODUCT_PACKAGES += \
     PrebuiltGmsCoreInstantApps
 endif
 
-ifneq ($(filter $(call get-allowed-api-levels),25),)
+ifneq ($(filter 25,$(call get-allowed-api-levels)),)
 GAPPS_PRODUCT_PACKAGES += \
     Turbo
 endif
 
-ifneq ($(filter $(call get-allowed-api-levels),26),)
+ifneq ($(filter 26,$(call get-allowed-api-levels)),)
 GAPPS_PRODUCT_PACKAGES += \
     AndroidPlatformServices
 endif
 
-ifneq ($(filter $(TARGET_GAPPS_VARIANT),nano),) # require at least nano
+ifneq ($(filter nano,$(TARGET_GAPPS_VARIANT)),) # require at least nano
 GAPPS_PRODUCT_PACKAGES += \
     FaceLock \
     Velvet
 
-ifneq ($(filter $(TARGET_GAPPS_VARIANT),micro),) # require at least micro
+ifneq ($(filter micro,$(TARGET_GAPPS_VARIANT)),) # require at least micro
 GAPPS_PRODUCT_PACKAGES += \
     CalendarGooglePrebuilt \
     PrebuiltExchange3Google \
     PrebuiltGmail \
     GoogleHome
 
-ifeq ($(filter $(call get-allowed-api-levels),23),)
+ifeq ($(filter 23,$(call get-allowed-api-levels)),)
 GAPPS_PRODUCT_PACKAGES += \
     GoogleTTS
 endif
 
-ifneq ($(filter $(TARGET_GAPPS_VARIANT),mini),) # require at least mini
+ifneq ($(filter mini,$(TARGET_GAPPS_VARIANT)),) # require at least mini
 GAPPS_PRODUCT_PACKAGES += \
     CalculatorGoogle \
     PrebuiltDeskClockGoogle \
@@ -67,7 +67,7 @@ GAPPS_PRODUCT_PACKAGES += \
     Photos \
     YouTube
 
-ifneq ($(filter $(TARGET_GAPPS_VARIANT),full),) # require at least full
+ifneq ($(filter full,$(TARGET_GAPPS_VARIANT)),) # require at least full
 
 GAPPS_FORCE_BROWSER_OVERRIDES := true
 GAPPS_PRODUCT_PACKAGES += \
@@ -86,7 +86,7 @@ GAPPS_PRODUCT_PACKAGES += \
     EditorsSlides \
     talkback
 
-ifneq ($(filter $(TARGET_GAPPS_VARIANT),stock),) # require at least stock
+ifneq ($(filter stock,$(TARGET_GAPPS_VARIANT)),) # require at least stock
 
 GAPPS_FORCE_MMS_OVERRIDES := true
 GAPPS_FORCE_WEBVIEW_OVERRIDES := true
@@ -97,17 +97,17 @@ GAPPS_PRODUCT_PACKAGES += \
     TagGoogle \
     GoogleVrCore
 
-ifneq ($(filter $(call get-allowed-api-levels),23),)
+ifneq ($(filter 23,$(call get-allowed-api-levels)),)
 GAPPS_FORCE_DIALER_OVERRIDES := true
 endif
-ifneq ($(filter $(call get-allowed-api-levels),24),)
+ifneq ($(filter 24,$(call get-allowed-api-levels)),)
 GAPPS_PRODUCT_PACKAGES += \
     GooglePrintRecommendationService \
     GoogleExtServices \
     GoogleExtShared
 endif
 
-ifneq ($(filter $(TARGET_GAPPS_VARIANT),super),)
+ifneq ($(filter super,$(TARGET_GAPPS_VARIANT)),)
 
 GAPPS_PRODUCT_PACKAGES += \
     Wallet \
@@ -137,19 +137,20 @@ endif # end nano
 PRODUCT_PACKAGES += $(filter-out $(GAPPS_EXCLUDED_PACKAGES),$(GAPPS_PRODUCT_PACKAGES))
 
 ifeq ($(GAPPS_FORCE_WEBVIEW_OVERRIDES),true)
-ifneq ($(filter-out $(call get-allowed-api-levels),24),)
-DEVICE_PACKAGE_OVERLAYS += \
-    $(GAPPS_DEVICE_FILES_PATH)/overlay/webview/21
-else
+# starting with nougat, use a different overlay
+ifneq ($(filter 24,$(call get-allowed-api-levels)),)
 DEVICE_PACKAGE_OVERLAYS += \
     $(GAPPS_DEVICE_FILES_PATH)/overlay/webview/24
+else
+DEVICE_PACKAGE_OVERLAYS += \
+    $(GAPPS_DEVICE_FILES_PATH)/overlay/webview/21
 endif
 PRODUCT_PACKAGES += \
     WebViewGoogle
 endif
 
 ifeq ($(GAPPS_FORCE_BROWSER_OVERRIDES),true)
-ifneq ($(filter $(call get-allowed-api-levels),23),)
+ifneq ($(filter 23,$(call get-allowed-api-levels)),)
 DEVICE_PACKAGE_OVERLAYS += \
     $(GAPPS_DEVICE_FILES_PATH)/overlay/browser
 endif
@@ -157,7 +158,7 @@ PRODUCT_PACKAGES += \
     Chrome
 endif
 
-ifneq ($(filter $(call get-allowed-api-levels),23),)
+ifneq ($(filter 23,$(call get-allowed-api-levels)),)
 ifeq ($(GAPPS_FORCE_DIALER_OVERRIDES),true)
 DEVICE_PACKAGE_OVERLAYS += \
     $(GAPPS_DEVICE_FILES_PATH)/overlay/dialer
@@ -176,18 +177,16 @@ PRODUCT_PACKAGES += \
 endif
 
 ifeq ($(GAPPS_FORCE_PIXEL_LAUNCHER),true)
-GAPPS_EXCLUDED_PACKAGES += \
-    GoogleHome
 
-ifneq ($(filter $(call get-allowed-api-levels),25),)
-ifneq ($(filter-out $(call get-allowed-api-levels),26),)
-DEVICE_PACKAGE_OVERLAYS += \
-    $(GAPPS_DEVICE_FILES_PATH)/overlay/pixelicons/25
-else
+ifneq ($(filter 26,$(call get-allowed-api-levels)),)
 DEVICE_PACKAGE_OVERLAYS += \
     $(GAPPS_DEVICE_FILES_PATH)/overlay/pixelicons/26
+else ifneq ($(filter 25,$(call get-allowed-api-levels)),)
+DEVICE_PACKAGE_OVERLAYS += \
+    $(GAPPS_DEVICE_FILES_PATH)/overlay/pixelicons/25
 endif
 
+ifneq ($(filter 25,$(call get-allowed-api-levels)),)
 PRODUCT_PACKAGES += \
     PixelLauncherIcons
 endif


### PR DESCRIPTION
The docs for gnu-make describe the "filter" function like this:
$(filter pattern...,text).  Multiple patterns can be given.

In our usage of the "filter" function, we had the parameters swapped
(but since we used non-wildcard patterns, we got the correct result
back).

Update "filter" parameters so they are in line with standard usage.