### PR TITLE
Move libfrsdk.so from vendor to system

### DIFF
--- a/modules/FaceLock/Android.mk
+++ b/modules/FaceLock/Android.mk
@@ -27,7 +27,6 @@ include $(BUILD_GAPPS_PREBUILT_SHARED_LIBRARY)
 include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := libfrsdk
-GAPPS_IS_VENDOR_LIB := true
 include $(BUILD_GAPPS_PREBUILT_SHARED_LIBRARY)
 
 # Cleanup temp variable


### PR DESCRIPTION
On most devices we don't build vendor images and use the Stock vendor images.

On stock, the lib is on system (Verified on the Pixel 2 XL running 8.1), so move it to system here too.