### PR TITLE
Stop including Nexus/Pixel sysconfig xmls on all devices

### DIFF
--- a/modules/GoogleDialer/Android.mk
+++ b/modules/GoogleDialer/Android.mk
@@ -9,3 +9,15 @@ GAPPS_LOCAL_OVERRIDES_MIN_VARIANT :=
 GAPPS_LOCAL_OVERRIDES_PACKAGES := Dialer
 
 include $(BUILD_GAPPS_PREBUILT_APK)
+
+include $(CLEAR_VARS)
+include $(GAPPS_CLEAR_VARS)
+
+LOCAL_MODULE := GoogleDialer_dialer_experience.xml
+LOCAL_MODULE_STEM := dialer_experience.xml
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_CLASS := ETC
+LOCAL_SRC_FILES := $(GAPPS_SOURCES_PATH)/all/etc/sysconfig/dialer_experience.xml
+LOCAL_MODULE_PATH := $(TARGET_OUT_ETC)/sysconfig
+
+include $(BUILD_PREBUILT)

--- a/opengapps-files.mk
+++ b/opengapps-files.mk
@@ -1,6 +1,46 @@
 # Always needed
-PRODUCT_COPY_FILES += $(call gapps-copy-to-system,all,etc)
 PRODUCT_COPY_FILES += $(call gapps-copy-to-system,all,framework)
+
+GAPPS_NEXUS_CODENAMES += \
+    full_maguro \
+    full_toro \
+    full_toroplus \
+    aosp_grouper \
+    aosp_tilapia \
+    aosp_manta \
+    aosp_mako \
+    aosp_flo \
+    aosp_deb \
+    aosp_hammerhead \
+    aosp_flounder \
+    aosp_shamu \
+    aosp_angler \
+    aosp_bullhead
+
+GAPPS_PIXEL_CODENAMES += \
+    aosp_marlin \
+    aosp_sailfish \
+    aosp_muskie \
+    aosp_taimen \
+    aosp_wahoo
+
+gapps_etc_files := $(call gapps-copy-to-system,all,etc)
+
+# Remove google_build.xml on non-Pixel devices
+ifeq ($(filter $(GAPPS_PIXEL_CODENAMES),$(TARGET_PRODUCT)),)
+  gapps_etc_files := $(filter-out %sysconfig/google_build.xml,$(gapps_etc_files))
+endif
+
+# Remove nexus.xml on non-Nexus devices
+ifeq ($(filter $(GAPPS_NEXUS_CODENAMES),$(TARGET_PRODUCT)),)
+  gapps_etc_files := $(filter-out %sysconfig/nexus.xml,$(gapps_etc_files))
+endif
+
+# This is included as part of GoogleDialer build, for devices that have the
+# GoogleDialer
+gapps_etc_files := $(filter-out %sysconfig/dialer_experience.xml,$(gapps_etc_files))
+
+PRODUCT_COPY_FILES += $(gapps_etc_files)
 
 # check if we are building a vendor image
 ifneq ($(CALLED_FROM_SETUP),true)
@@ -21,3 +61,6 @@ endif
 endif
   PRODUCT_COPY_FILES += $(call gapps-copy-to-system,all,usr/srec)
 endif
+
+# Reset internal variables
+gapps_etc_files :=

--- a/opengapps-packages.mk
+++ b/opengapps-packages.mk
@@ -164,7 +164,8 @@ DEVICE_PACKAGE_OVERLAYS += \
     $(GAPPS_DEVICE_FILES_PATH)/overlay/dialer
 
 PRODUCT_PACKAGES += \
-    GoogleDialer
+    GoogleDialer \
+    GoogleDialer_dialer_experience.xml
 endif
 endif
 


### PR DESCRIPTION
This fixes issues where any device building with OpenGapps would
believe it's a Google Pixel device.

Fixes issue #134