### PR TITLE
Use GAPPS_EXCLUDED_PACKAGES to guard invalid module error

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ You can add packages from versions higher then your set version. E.g. if you wan
 In your `device/manufacturer/product/device.mk` just add, for example:
 
 ```makefile
-PRODUCT_PACKAGES += Chrome
+GAPPS_PRODUCT_PACKAGES += Chrome
 ```
 
 This uses the module name. You can find the module name for a package by checking `vendor/opengapps/build/modules/` and look at the `LOCAL_MODULE` value.

--- a/core/prebuilt_apk.mk
+++ b/core/prebuilt_apk.mk
@@ -47,7 +47,13 @@ else
 endif
 
 ifndef LOCAL_SRC_FILES
-  $(error Unable to find APK for $(LOCAL_MODULE))
+# the three calls to find-apk-for-pkg above all failed.
+# emit an error, unless the module is listed in GAPPS_EXCLUDED_PACKAGES.
+ifeq (,$(filter $(LOCAL_MODULE),$(GAPPS_EXCLUDED_PACKAGES)))
+  $(warning Unable to find an architecture compatible APK for package $(LOCAL_PACKAGE_NAME) defined in module $(LOCAL_MODULE).)
+  $(warning You can try using GAPPS_EXCLUDED_PACKAGES += $(LOCAL_MODULE) to get past this error.)
+  $(error Invalid build module: $(LOCAL_MODULE))
+endif
 endif
 
 include $(BUILD_PREBUILT)

--- a/core/prebuilt_apk.mk
+++ b/core/prebuilt_apk.mk
@@ -48,11 +48,13 @@ endif
 
 ifndef LOCAL_SRC_FILES
 # the three calls to find-apk-for-pkg above all failed.
-# emit an error, unless the module is listed in GAPPS_EXCLUDED_PACKAGES.
-ifeq (,$(filter $(LOCAL_MODULE),$(GAPPS_EXCLUDED_PACKAGES)))
+# emit an error if the module is in the set GAPPS_PRODUCT_PACKAGES - GAPPS_EXCLUDED_PACKAGES
+ifneq (,$(filter $(LOCAL_MODULE),$(GAPPS_PRODUCT_PACKAGES)))
+ifeq  (,$(filter $(LOCAL_MODULE),$(GAPPS_EXCLUDED_PACKAGES)))
   $(warning Unable to find an architecture compatible APK for package $(LOCAL_PACKAGE_NAME) defined in module $(LOCAL_MODULE).)
   $(warning You can try using GAPPS_EXCLUDED_PACKAGES += $(LOCAL_MODULE) to get past this error.)
   $(error Invalid build module: $(LOCAL_MODULE))
+endif
 endif
 endif
 


### PR DESCRIPTION
For modules that use "include $(BUILD_GAPPS_PREBUILT_APK)", if we
cannot locate an architecture compatible apk to install, then we treat
that module as invalid and issue an error.  To work around such
errors, the user might use GAPPS_EXCLUDED_PACKAGES, so check that
variable first before erroring-out.