### PR TITLE
Fix multiarch support

### DIFF
--- a/core/prebuilt_apk.mk
+++ b/core/prebuilt_apk.mk
@@ -40,6 +40,7 @@ else
     ifdef TARGET_2ND_ARCH
       LOCAL_SRC_FILES := $(call find-apk-for-pkg,$(TARGET_2ND_ARCH),$(LOCAL_PACKAGE_NAME))
       ifdef LOCAL_SRC_FILES
+        LOCAL_MODULE_TARGET_ARCH := $(TARGET_2ND_ARCH)
         LOCAL_PREBUILT_JNI_LIBS_$(TARGET_2ND_ARCH) := $(call find-libs-in-apk,$(TARGET_2ND_ARCH),$(LOCAL_SRC_FILES))
       endif
     endif


### PR DESCRIPTION
Android build system doesn't extract JNI libs from prebuilt APK files on latest Android versions, and ignoring LOCAL_PREBUILT_JNI_LIBS value. It repacks them with no compression instead, and uses directly from an APK, but for target arch only. This value will be ignored by older Android versions, so checking of target Android version isn't necessary.

E.g. if you specified arm64 as your TARGET_ARCH, but your APK has 32-bit libs only, you'll get UnsatisfiedLinkError on runtime.

So, you must build whole APK to the 2nd arch, to let VM know that APK has only this arch support.

Signed-off-by: Ganster41 <ganster0x29@gmail.com>