### PR TITLE
make pixel launcher default launcher for oreo and newer android releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ If you want to include Chrome on a non-full build you need:
 GAPPS_FORCE_BROWSER_OVERRIDES := true
 ```
 
-If you want use PixelLauncher overriding GoogleHome you need:
+If you want use PixelLauncher (Default from Oreo) overriding GoogleHome you need:
 
 ```makefile
 GAPPS_FORCE_PIXEL_LAUNCHER := true

--- a/opengapps-packages.mk
+++ b/opengapps-packages.mk
@@ -59,8 +59,14 @@ ifneq ($(filter micro,$(TARGET_GAPPS_VARIANT)),) # require at least micro
 GAPPS_PRODUCT_PACKAGES += \
     CalendarGooglePrebuilt \
     PrebuiltExchange3Google \
-    PrebuiltGmail \
+    PrebuiltGmail
+
+ifneq ($(filter 26,$(call get-allowed-api-levels)),)
+GAPPS_FORCE_PIXEL_LAUNCHER := true
+else
+GAPPS_PRODUCT_PACKAGES += \
     GoogleHome
+endif
 
 ifeq ($(filter 23,$(call get-allowed-api-levels)),)
 GAPPS_PRODUCT_PACKAGES += \


### PR DESCRIPTION
Signed-off-by: David Viteri <davidteri91@gmail.com>