### PR TITLE
Add module for AndroidMigratePrebuilt

### DIFF
--- a/modules/AndroidMigratePrebuilt/Android.mk
+++ b/modules/AndroidMigratePrebuilt/Android.mk
@@ -1,0 +1,9 @@
+LOCAL_PATH := .
+include $(CLEAR_VARS)
+include $(GAPPS_CLEAR_VARS)
+LOCAL_MODULE := AndroidMigratePrebuilt
+# aka Data Transfer Tool
+LOCAL_PACKAGE_NAME := com.google.android.apps.pixelmigrate
+LOCAL_PRIVILEGED_MODULE := true
+
+include $(BUILD_GAPPS_PREBUILT_APK)

--- a/opengapps-packages.mk
+++ b/opengapps-packages.mk
@@ -42,7 +42,8 @@ endif
 ifneq ($(filter 26,$(call get-allowed-api-levels)),)
 GAPPS_PRODUCT_PACKAGES += \
     AndroidPlatformServices \
-    GmsCoreSetupPrebuilt
+    GmsCoreSetupPrebuilt \
+    AndroidMigratePrebuilt
 endif
 
 ifneq ($(filter 28,$(call get-allowed-api-levels)),)


### PR DESCRIPTION
AndroidMigratePrebuilt, also known as Data Transfer Tool, is launched
by SetupWizard.  If it is not pre-installed, then it may be downloaded
and installed by SetupWizard.  In that case, the downloaded version
does not receive the required permissions and will crash when run.
The pre-installed version is granted the necessary permissions because
of an entry in the opengapps file privapp-permissions-google.xml:

  https://github.com/GraphiteSoftware/all/blob/master/etc/permissions/privapp-permissions-google.xml