### PR TITLE
overlay: Define Google Assistant as default

### DIFF
--- a/opengapps-packages.mk
+++ b/opengapps-packages.mk
@@ -5,6 +5,11 @@ include vendor/opengapps/build/opengapps-files.mk
 DEVICE_PACKAGE_OVERLAYS += \
     $(GAPPS_DEVICE_FILES_PATH)/overlay/pico
 
+ifneq ($(filter 28,$(call get-allowed-api-levels)),)
+DEVICE_PACKAGE_OVERLAYS += \
+    $(GAPPS_DEVICE_FILES_PATH)/overlay/assistant/28
+endif
+
 GAPPS_PRODUCT_PACKAGES += \
     GoogleBackupTransport \
     GoogleContactsSyncAdapter \

--- a/overlay/assistant/28/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/assistant/28/frameworks/base/core/res/res/values/config.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+** Copyright 2011, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<!-- These resources are around just to allow their values to be customized
+     for different hardware and product builds. -->
+<resources>
+    <!-- Component name for default assistant on this device -->
+    <string name="config_defaultAssistantComponentName">com.google.android.googlequicksearchbox/com.google.android.voiceinteraction.GsaVoiceInteractionService</string>
+</resources>


### PR DESCRIPTION
Google introduced that on r21 patch

https://github.com/PixelExperience/frameworks_base/commit/7105e37a8c6d4dcf95695298486b25b8c43a6a7e and https://github.com/PixelExperience/frameworks_base/commit/3a1a64c045ffe89823d8cf2df17655d119f967ba