### PR TITLE
Properly separate lunzip arguments.

### DIFF
--- a/core/find_apk.sh
+++ b/core/find_apk.sh
@@ -12,16 +12,18 @@ getlatestapk() {
   # handled correctly in the for-loops below.
 
   local LZ_DECOMPRESS_CMD="false"
+  local LZ_DECOMPRESS_ARG=""
   if command -v lunzip > /dev/null; then
     LZ_DECOMPRESS_CMD="lunzip"
   elif command -v lzip > /dev/null; then
-    LZ_DECOMPRESS_CMD="lzip --decompress"
+    LZ_DECOMPRESS_CMD="lzip"
+    LZ_DECOMPRESS_ARG="--decompress"
   fi;
 
   # decompress apks
   # some apks are lz compressed to work around github file-size limits.
   for foundapklz in $(find "$1" -iname '*.apk.lz'); do
-    $LZ_DECOMPRESS_CMD --keep "$foundapklz" || echo "Warning: lz decompress command failed for $foundapklz" >&2
+    $LZ_DECOMPRESS_CMD $LZ_DECOMPRESS_ARG --keep "$foundapklz" || echo "Warning: lz decompress command failed for $foundapklz" >&2
   done
 
   # sed copies filename to the beginning, to compare version, and later we remove it with cut


### PR DESCRIPTION
At least on my Fedora 29 machine, having command and argument in one
shell variable causes them to be used as argv[0], IOW, the script will
run "lzip --decompress" --keep [...] which obviously leads to failure.