### PR TITLE
Only include Android.mk of selected gapps

### DIFF
--- a/modules/Android.mk
+++ b/modules/Android.mk
@@ -1,0 +1,1 @@
+include $(call all-named-subdir-makefiles,$(GAPPS_PRODUCT_PACKAGES))


### PR DESCRIPTION
Some apps don't exist in all archs. Only include makefiles of selected
apps to avoid such errors:

[570/645] including vendor/opengapps/build/modules/ActionsServices/Android.mk ...
error: ActionsServices: No source files specified