### PR TITLE
[WIP] Include webview overlay when forcing Chrome browser.

### DIFF
--- a/opengapps-packages.mk
+++ b/opengapps-packages.mk
@@ -184,6 +184,11 @@ ifneq ($(filter 23,$(call get-allowed-api-levels)),)
 DEVICE_PACKAGE_OVERLAYS += \
     $(GAPPS_DEVICE_FILES_PATH)/overlay/browser
 endif
+# Chrome supplies a webview, include the overlay:
+ifneq ($(filter 24,$(call get-allowed-api-levels)),)
+DEVICE_PACKAGE_OVERLAYS += \
+     $(GAPPS_DEVICE_FILES_PATH)/overlay/webview/24
+endif
 PRODUCT_PACKAGES += \
     Chrome
 endif


### PR DESCRIPTION
Chrome supplies a webview as well, but is not listed as such when GAPPS_FORCE_WEBVIEW_OVERRIDES is not true. It has to be listed in the webviewproviders overlay to show up.
Subsequently, setupwizard fails halfway when it needs to use a webview.

This is probably wrong as it is overriding webviews without `GAPPS_FORCE_WEBVIEW_OVERRIDES` set. Can we come up with an alternative that makes Chrome the sole webview provider without including `WebViewChrome` in the build?