### PR TITLE
[Android 10] find_apk: Replace `rev` with longest substring removal for DPI parsing.

### DIFF
--- a/core/find_apk.sh
+++ b/core/find_apk.sh
@@ -74,8 +74,9 @@ getlatestapk() {
       
       if [ "$2" != "nodpi" ]; then
         # Check if the package dpi is a range and if the device falls between that range
-        lodpi=$(echo "$dpi" | cut -d '-' -f 1)
-        if [[ "$lodpi" != "$dpi" && "$lodpi" -le "$2" && $(echo "$dpi" | rev | cut -d '-' -f 1 | rev) -ge "$2" ]]; then
+        lodpi=${dpi%%-*}
+        hidpi=${dpi##*-}
+        if [[ "$lodpi" != "$dpi" && "$lodpi" -le "$2" && "$hidpi" -ge "$2" ]]; then
           sourceapk="$foundapk"
           break;
         fi
@@ -94,7 +95,7 @@ getlatestapk() {
         dpi="$(basename "$dpipath")"
         # If this is a range, we already know the device is either over or under that range.
         # Therefore, we can safely take any value.
-        dpi=$(echo "$dpi" | cut -d '-' -f 1)
+        dpi=${dpi%%-*}
         if [ "$dpi" -ge "$2" ]; then
           sourceapk="$foundapk"
         else
@@ -131,9 +132,10 @@ getconformapk() {
   for foundapk in $(find "$1" -iname '*.apk' | sed 's!.*/\(.*\)!\1/&!' | sort -r -t/ -k1,1 -n | cut -d/ -f2-); do
     founddpipath="$(dirname "$foundapk")"
     dpi="$(basename "$founddpipath")"
-    lodpi=$(echo "$dpi" | cut -d '-' -f 1)
+    lodpi=${dpi%%-*}
+    hidpi=${dpi##*-}
     if [[ "$dpi" = "nodpi" || "$dpi" = "$2"
-       || ( "$2" != "nodpi" && "$lodpi" != "$dpi" && "$lodpi" -le "$2" && $(echo "$dpi" | rev | cut -d '-' -f 1 | rev) -ge "$2" ) ]]; then
+       || ( "$2" != "nodpi" && "$lodpi" != "$dpi" && "$lodpi" -le "$2" && "$hidpi" -ge "$2" ) ]]; then
         sourceapk="$foundapk"
         break;
     fi


### PR DESCRIPTION
rev is not available as path tool in the Android 10 build system:
https://android.googlesource.com/platform/build/+/master/Changes.md#PATH_Tools

While this will only generate warnings for the time being, extracting
the first and last number from a dpi sequence a-b-c can be implemented
natively in bash without requiring a subprocess. Note that _longest_
prefix/postfix match is used, to strip off anything before/after the
dash.