### PR TITLE
opengapps-packages: Exclude FaceLock on API >= 29.

### DIFF
--- a/modules/FaceLock/Android.mk
+++ b/modules/FaceLock/Android.mk
@@ -1,4 +1,8 @@
 ifneq ($(filter arm%, $(TARGET_ARCH)),)
+
+# FaceLock is only available on API < 29
+ifeq ($(filter 29,$(call get-allowed-api-levels)),)
+
 # libfacelock_jni.so was renamed to libfacenet.so in Nougat+
 ifeq ($(filter 24,$(call get-allowed-api-levels)),)
 FACELOCK_JNI_NAME := libfacelock_jni
@@ -31,4 +35,5 @@ include $(BUILD_GAPPS_PREBUILT_SHARED_LIBRARY)
 
 # Cleanup temp variable
 FACELOCK_JNI_NAME :=
-endif
+endif # API < 29
+endif # arm

--- a/opengapps-packages.mk
+++ b/opengapps-packages.mk
@@ -54,8 +54,13 @@ endif
 ifneq ($(filter nano,$(TARGET_GAPPS_VARIANT)),) # require at least nano
 GAPPS_PRODUCT_PACKAGES += \
     libjni_latinimegoogle \
-    FaceLock \
     Velvet
+
+# FaceLock is only available on API < 29
+ifeq ($(filter 29,$(call get-allowed-api-levels)),)
+GAPPS_PRODUCT_PACKAGES += \
+    FaceLock
+endif
 
 ifneq ($(filter 28,$(call get-allowed-api-levels)),)
 GAPPS_PRODUCT_PACKAGES += \


### PR DESCRIPTION
Fixes https://github.com/opengapps/aosp_build/issues/238

FaceLock is not compatible with Android 10 anymore, and has been removed
from the source repos.