### PR TITLE
modules: Load TrichromeLibrary module only on API >= 29.

### DIFF
--- a/modules/TrichromeLibrary/Android.mk
+++ b/modules/TrichromeLibrary/Android.mk
@@ -1,3 +1,5 @@
+ifneq ($(filter 29,$(call get-allowed-api-levels)),)
+
 LOCAL_PATH := .
 include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
@@ -5,3 +7,5 @@ LOCAL_MODULE := TrichromeLibrary
 LOCAL_PACKAGE_NAME := com.google.android.trichromelibrary
 
 include $(BUILD_GAPPS_PREBUILT_APK)
+
+endif # API >= 29


### PR DESCRIPTION
Fixes https://github.com/opengapps/aosp_build/issues/237

The APK for this module only exists on API level 29. Builds for Android
9 and below will fail due to the missing APK on a lower or matching API
level.
Besides, this module is never added to LOCAL_REQUIRED_MODULES on API
levels lower than 29 anyway.

Fixes: 191c464a3fcb28b1938a47ba74713c712101c3cd
Signed-off-by: MarijnS95 <marijns95@gmail.com>