### PR TITLE
opengapps-packages: Make appropriate apps a privilege module

### DIFF
--- a/modules/ActionsServices/Android.mk
+++ b/modules/ActionsServices/Android.mk
@@ -3,5 +3,6 @@ include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := ActionsServices
 LOCAL_PACKAGE_NAME := com.google.android.as
+LOCAL_PRIVILEGED_MODULE := true
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/AndroidPlatformServices/Android.mk
+++ b/modules/AndroidPlatformServices/Android.mk
@@ -5,6 +5,7 @@ include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := AndroidPlatformServices
 LOCAL_PACKAGE_NAME := com.google.android.gms.policy_sidecar_o
 GAPPS_LOCAL_OVERRIDES_PACKAGES := GoogleLoginService
+LOCAL_PRIVILEGED_MODULE := true
 
 include $(BUILD_GAPPS_PREBUILT_APK)
 endif

--- a/modules/CarrierServices/Android.mk
+++ b/modules/CarrierServices/Android.mk
@@ -3,5 +3,6 @@ include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := CarrierServices
 LOCAL_PACKAGE_NAME := com.google.android.ims
+LOCAL_PRIVILEGED_MODULE := true
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/StorageManagerGoogle/Android.mk
+++ b/modules/StorageManagerGoogle/Android.mk
@@ -3,5 +3,6 @@ include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := StorageManagerGoogle
 LOCAL_PACKAGE_NAME := com.google.android.storagemanager
+LOCAL_PRIVILEGED_MODULE := true
 
 include $(BUILD_GAPPS_PREBUILT_APK)


### PR DESCRIPTION
Based on official packages and priv-app permissions, these app should've been placed in priv-app instead of app. This also fix Actions services not providing any meaningful functionality even though the appropriate overlay has been applied.