### PR TITLE
Rename TrichromeLibrary to TrichromeLibraryGoogle

### DIFF
--- a/modules/Chrome/Android.mk
+++ b/modules/Chrome/Android.mk
@@ -9,7 +9,7 @@ GAPPS_LOCAL_OVERRIDES_PACKAGES := Browser Browser2 BrowserProviderProxy Chromium
 
 ifneq ($(filter 29,$(call get-allowed-api-levels)),)
 LOCAL_REQUIRED_MODULES += \
-    TrichromeLibrary
+    TrichromeLibraryGoogle
 endif
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/TrichromeLibrary/Android.mk
+++ b/modules/TrichromeLibrary/Android.mk
@@ -1,7 +1,7 @@
 LOCAL_PATH := .
 include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
-LOCAL_MODULE := TrichromeLibrary
+LOCAL_MODULE := TrichromeLibraryGoogle
 LOCAL_PACKAGE_NAME := com.google.android.trichromelibrary
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/WebViewGoogle/Android.mk
+++ b/modules/WebViewGoogle/Android.mk
@@ -11,7 +11,7 @@ LOCAL_REQUIRED_MODULES := libwebviewchromium_loader \
 
 ifneq ($(filter 29,$(call get-allowed-api-levels)),)
 LOCAL_REQUIRED_MODULES += \
-    TrichromeLibrary
+    TrichromeLibraryGoogle
 endif
 
 include $(BUILD_GAPPS_PREBUILT_APK)


### PR DESCRIPTION
LineageOS prepares patches to add TrichromeLibrary
https://review.lineageos.org/q/topic:ten-trichrome

which cause a build error:

including vendor/opengapps/build/modules/TrichromeLibrary/Android.mk ...
FAILED:
build/make/core/base_rules.mk:325: error: .:
 MODULE.TARGET.APPS.TrichromeLibrary already defined by vendor/chromium.