### PR TITLE
Allow PixelLauncher to override TrebuchetQuickStep

### DIFF
--- a/modules/PixelLauncher/Android.mk
+++ b/modules/PixelLauncher/Android.mk
@@ -5,6 +5,6 @@ LOCAL_MODULE := PixelLauncher
 LOCAL_PACKAGE_NAME := com.google.android.apps.nexuslauncher
 LOCAL_PRIVILEGED_MODULE := true
 
-GAPPS_LOCAL_OVERRIDES_PACKAGES := Home GoogleNow Launcher2 Launcher3 Launcher3Go Launcher3QuickStep Launcher3QuickStepGo Fluctuation Trebuchet
+GAPPS_LOCAL_OVERRIDES_PACKAGES := Home GoogleNow Launcher2 Launcher3 Launcher3Go Launcher3QuickStep Launcher3QuickStepGo Fluctuation Trebuchet TrebuchetQuickStep
 
 include $(BUILD_GAPPS_PREBUILT_APK)


### PR DESCRIPTION
The package is renamed from Trebuchet to TrebuchetQuickStep in Android 9 and 10

https://review.lineageos.org/c/LineageOS/android_vendor_lineage/+/232659

Signed-off-by: David Trpchevski <trpcevski.david@gmail.com>