### PR TITLE
Override tvlauncher no-gms variants

### DIFF
--- a/modules/TVLauncher/Android.mk
+++ b/modules/TVLauncher/Android.mk
@@ -3,6 +3,7 @@ include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := TVLauncher
 LOCAL_PACKAGE_NAME := com.google.android.tvlauncher.leanback
+GAPPS_LOCAL_OVERRIDES_PACKAGES := TVLauncherNoGMS
 LOCAL_PRIVILEGED_MODULE := true
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/modules/TVRecommendations/Android.mk
+++ b/modules/TVRecommendations/Android.mk
@@ -3,6 +3,7 @@ include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := TVRecommendations
 LOCAL_PACKAGE_NAME := com.google.android.tvrecommendations.leanback
+GAPPS_LOCAL_OVERRIDES_PACKAGES := TVRecommendationsNoGMS
 LOCAL_PRIVILEGED_MODULE := true
 
 include $(BUILD_GAPPS_PREBUILT_APK)


### PR DESCRIPTION
This is the naming used by Lineage OS for the no-gms builds of tvlauncher and tvrecommendations which Google released for aosp.