### PR TITLE
Initial support for Android 11

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -37,7 +37,7 @@ ifeq ($(GAPPS_FORCE_MATCHING_DPI),)
 endif
 
 ifeq ($(GAPPS_FORCE_MATCHING_DPI),false)
-  GAPPS_AAPT_PATH := $(shell find prebuilts/sdk/tools/$(HOST_OS) -executable -name aapt | head -n 1)
+  GAPPS_AAPT_PATH := $(shell find prebuilts/sdk/tools/$(HOST_OS) -perm /111 -name aapt | head -n 1)
   # Check if aapt is present in prebuilts or if it is installed.
   ifeq ($(wildcard $(GAPPS_AAPT_PATH)),)
     GAPPS_TEST_AAPT := $(shell command -v aapt)

--- a/config.mk
+++ b/config.mk
@@ -48,15 +48,3 @@ ifeq ($(GAPPS_FORCE_MATCHING_DPI),false)
     endif
   endif
 endif
-
-GAPPS_LUNZIP_REQUIRED := $(shell find $(GAPPS_SOURCES_PATH) -name '*.apk.lz' -print -quit)
-ifneq ($(GAPPS_LUNZIP_REQUIRED),)
-  GAPPS_TEST_LUNZIP := $(shell command -v lunzip)$(shell command -v lzip)
-  ifeq ($(GAPPS_TEST_LUNZIP),)
-    $(error lzip decompressor not available. Please install one first ("sudo apt-get install lunzip" or "sudo apt-get install lzip"))
-  endif
-
-  ifneq ($(filter clean installclean, $(MAKECMDGOALS)),)
-    $(shell find $(GAPPS_SOURCES_PATH) -name "*apk.lz" | sed 's/\.apk\.lz$$/\.apk/' | xargs rm -f)
-  endif
-endif

--- a/core/definitions.mk
+++ b/core/definitions.mk
@@ -23,7 +23,7 @@ $(if $(filter arm,$(1)),lib/armeabi*/*,lib/$(1)*/*)
 endef
 
 define find-libs-in-apk
-$(addprefix @,$(shell zipinfo -1 "$(2)" | grep "$(call get-lib-search-path, $(1))" | grep -v -E "*/crazy.*"))
+$(addprefix @,$(shell zipinfo -1 "$(2)" | grep "$(call get-lib-search-path, $(1))" | grep -v "*/crazy.*"))
 endef
 
 define get-gapps-variant

--- a/modules/SoundPicker/Android.mk
+++ b/modules/SoundPicker/Android.mk
@@ -1,8 +1,10 @@
 LOCAL_PATH := .
 include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
-LOCAL_MODULE := SoundPicker
+LOCAL_MODULE := GoogleSoundPicker
 LOCAL_PACKAGE_NAME :=  com.google.android.soundpicker
 LOCAL_PRIVILEGED_MODULE := true
+
+GAPPS_LOCAL_OVERRIDES_PACKAGES := SoundPicker
 
 include $(BUILD_GAPPS_PREBUILT_APK)

--- a/opengapps-packages.mk
+++ b/opengapps-packages.mk
@@ -111,7 +111,7 @@ ifneq ($(filter 28,$(call get-allowed-api-levels)),)
 GAPPS_PRODUCT_PACKAGES += \
     DigitalWellbeing \
     MarkupGoogle \
-    SoundPicker
+    GoogleSoundPicker
 endif
 
 ifneq ($(filter micro,$(TARGET_GAPPS_VARIANT)),) # require at least micro


### PR DESCRIPTION
Please review individual commits for implementation details. Obviously requires Android 11 (SDK 30) apks of some apps (setupwizard, gms, gsf, (tri)chrome, webview, etc) to run on-device.

~This requires testing on Android 10 before it can be merged.~ Tested on Android 10.

@nezorflame any plans towards supporting `.apk.gz`, found on Android 11 Pixel images?
