### PR TITLE
[master] Satisfy check_elf_file.py requirements

### DIFF
--- a/modules/LatinImeGoogle/Android.mk
+++ b/modules/LatinImeGoogle/Android.mk
@@ -14,4 +14,5 @@ include $(BUILD_GAPPS_PREBUILT_APK)
 include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := libjni_latinimegoogle
+LOCAL_SHARED_LIBRARIES := libstdc++
 include $(BUILD_GAPPS_PREBUILT_SHARED_LIBRARY)

--- a/modules/MarkupGoogle/Android.mk
+++ b/modules/MarkupGoogle/Android.mk
@@ -10,4 +10,5 @@ include $(BUILD_GAPPS_PREBUILT_APK)
 include $(CLEAR_VARS)
 include $(GAPPS_CLEAR_VARS)
 LOCAL_MODULE := libsketchology_native
+LOCAL_SHARED_LIBRARIES := libEGL libGLESv1_CM libGLESv2 libandroid libjnigraphics liblog
 include $(BUILD_GAPPS_PREBUILT_SHARED_LIBRARY)


### PR DESCRIPTION
If not, they will fail building (on Android 11, at least).

This has been tested on top of https://github.com/opengapps/aosp_build/pull/272.