### PR TITLE
ignore TrichromeLibrary since it doesn't extist for arm

### DIFF
--- a/modules/TrichromeLibrary/Android.mk
+++ b/modules/TrichromeLibrary/Android.mk
@@ -1,4 +1,5 @@
 ifneq ($(filter 29,$(call get-allowed-api-levels)),)
+ifneq ($(TARGET_ARCH),arm)
 
 LOCAL_PATH := .
 include $(CLEAR_VARS)
@@ -7,5 +8,5 @@ LOCAL_MODULE := TrichromeLibraryGoogle
 LOCAL_PACKAGE_NAME := com.google.android.trichromelibrary
 
 include $(BUILD_GAPPS_PREBUILT_APK)
-
+endif #arm
 endif # API >= 29


### PR DESCRIPTION
similar to issue #222 I get build errors during makefile gathering for nonexisting packets on arm:

``[ 99% 13085/13114] including vendor/opengapps/build/modules/TrichromeLibrary/Android.mk ...                                             
FAILED:                                                                                                                                 
zipinfo:  cannot find or open , .zip or .ZIP.                                                                                           
vendor/opengapps/build/modules/GoogleWebViewOverlay/Android.mk: error: TrichromeLibraryGoogle: No source files specified                
build/make/core/prebuilt_internal.mk:37: error: done.                                                                                   
10:28:56 ckati failed with: exit status 1  ``

...since TrichromeLibrary doesn't exist on arm only on arm64...thus it should be excluded from makefiles