### PR TITLE
Add AndroidAuto module and add to stock target

### DIFF
--- a/modules/AndroidAuto/Android.mk
+++ b/modules/AndroidAuto/Android.mk
@@ -1,0 +1,8 @@
+LOCAL_PATH := .
+include $(CLEAR_VARS)
+include $(GAPPS_CLEAR_VARS)
+LOCAL_MODULE := AndroidAuto
+LOCAL_PACKAGE_NAME := com.google.android.projection.gearhead
+LOCAL_PRIVILEGED_MODULE := true
+
+include $(BUILD_GAPPS_PREBUILT_APK)

--- a/opengapps-packages.mk
+++ b/opengapps-packages.mk
@@ -163,6 +163,7 @@ ifneq ($(filter stock,$(TARGET_GAPPS_VARIANT)),) # require at least stock
 GAPPS_FORCE_MMS_OVERRIDES := true
 GAPPS_FORCE_WEBVIEW_OVERRIDES := true
 GAPPS_PRODUCT_PACKAGES += \
+    AndroidAuto \
     GoogleCamera \
     GoogleContacts \
     LatinImeGoogle \


### PR DESCRIPTION
There is currently no AndroidAuto module, so add it and add it to the stock target to bring inline with the zips.

Note that there are some privapp-permission updates needed for Auto, at least on 11 - this patch is required: https://gist.github.com/Tortel/a3d952eeea23dc13447376319e6dbb90

I created an account on GitLab to open a pull request for that change, but my account is pending approval.