### PR TITLE
opengapps-packages: Remove CloudPrint2

### DIFF
--- a/modules/CloudPrint2/Android.mk
+++ b/modules/CloudPrint2/Android.mk
@@ -1,7 +1,0 @@
-LOCAL_PATH := .
-include $(CLEAR_VARS)
-include $(GAPPS_CLEAR_VARS)
-LOCAL_MODULE := CloudPrint2
-LOCAL_PACKAGE_NAME := com.google.android.apps.cloudprint
-
-include $(BUILD_GAPPS_PREBUILT_APK)

--- a/opengapps-packages.mk
+++ b/opengapps-packages.mk
@@ -145,7 +145,6 @@ ifneq ($(filter full,$(TARGET_GAPPS_VARIANT)),) # require at least full
 GAPPS_FORCE_BROWSER_OVERRIDES := true
 GAPPS_PRODUCT_PACKAGES += \
     Books \
-    CloudPrint2 \
     EditorsDocs \
     Drive \
     FitnessPrebuilt \


### PR DESCRIPTION
Package was removed from the repo:
https://gitlab.opengapps.org/opengapps/all/-/commit/56c4d6a5879a81a648be3f409ca62661c996cf72

Fixes build error:

[ 87% 701/798] including vendor/opengapps/build/modules/CloudPrint2/Android.mk ...
FAILED: error: CloudPrint2: No source files specified